### PR TITLE
Improve validation list screen reader experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A web component that provides visual validation feedback for form fields using a
 
 - **Light DOM** - Uses light DOM for better accessibility and SEO
 - **Pattern-based validation** - Define rules using regular expressions
-- **Accessible** - Proper ARIA attributes and screen reader support
-- **Customizable** - Configure classes and icons via CSS custom properties
+- **Accessible** - Single live summary while typing, with full criteria state restored on blur
+- **Customizable** - Configure classes, icons, and localized rule state strings
 - **Browser validation integration** - Participates in native form validation using `setCustomValidity`
 - **Event-driven** - Fires custom events for programmatic interaction
 - **Visual feedback** - Animated cascade effect when validating rules
@@ -17,7 +17,7 @@ A web component that provides visual validation feedback for form fields using a
 ## TypeScript & Framework Support
 
 - Ships with bundled `.d.ts` definitions so editors and TypeScript builds understand `FormValidationListElement` and `defineFormValidationList`.
-- `for`, `trigger-event`, `input-throttle`, `each-delay`, and every class-related attribute now reflect between properties and attributes, keeping reactive frameworks and declarative templates in sync with DOM state.
+- `for`, `trigger-event`, `input-throttle`, `each-delay`, the icon/state text attributes, and every class-related attribute reflect between properties and attributes, keeping reactive frameworks and declarative templates in sync with DOM state.
 - An internal `_upgradeProperty` helper captures properties that were assigned before the element upgraded, ensuring early property sets (common in SSR or JSX) are not lost.
 - The `HTMLElementTagNameMap` is augmented so `document.querySelector('form-validation-list')` is strongly typed in TS/JSX projects.
 
@@ -93,10 +93,12 @@ You can also include the guarded script from HTML:
 1. Add a `for` attribute to the `<form-validation-list>` element with the ID of the input field you want to validate
 2. Inside the element, add list items (or any elements) with a `data-pattern` attribute containing a regular expression
 3. As the user types, the component will test the input value against each pattern
-4. Matched rules get the `validation-matched` class and show a checkmark
-5. Unmatched rules get the `validation-unmatched` class and show an X
-6. When all rules are matched, the field gets the `validation-valid` class
-7. The component uses `setCustomValidity()` to participate in the browser's form validation
+4. While typing, the field temporarily stops referencing the full criteria list via `aria-describedby` to avoid duplicate announcements
+5. A single polite live region announces the localized summary using the `announcement` template
+6. Matched rules get the `validation-matched` class and show a checkmark; unmatched rules get `validation-unmatched` and show an X
+7. Once the field has a value, each rule also includes visually hidden localized state text such as "Criteria met" or "Criteria not met"
+8. On blur, the field's `aria-describedby` is restored so returning to the field reads the full criteria state again
+9. The component uses `setCustomValidity()` to participate in the browser's form validation
 
 ## Attributes
 
@@ -110,6 +112,11 @@ You can also include the guarded script from HTML:
 | `field-valid-class` | `string` | `"validation-valid"` | Class to apply to the field when valid |
 | `rule-unmatched-class` | `string` | `"validation-unmatched"` | Class to apply to unmatched rules |
 | `rule-matched-class` | `string` | `"validation-matched"` | Class to apply to matched rules |
+| `rule-matched-icon` | `string` | `"✓"` | Override the matched icon glyph for this instance |
+| `rule-unmatched-icon` | `string` | `"✗"` | Override the unmatched icon glyph for this instance |
+| `rule-matched-alt` | `string` | `"Criteria met"` | Localized hidden state text inserted for matched rules once the field has a value |
+| `rule-unmatched-alt` | `string` | `"Criteria not met"` | Localized hidden state text inserted for unmatched rules once the field has a value |
+| `announcement` | `string` | `"Criteria met: {matched} of {total}"` | Live region summary while typing. Use `{matched}` and `{total}` placeholders. |
 | `validation-message` | `string` | `"Please match all validation requirements ({matched} of {total})"` | Custom validation message template. Use `{matched}` and `{total}` as placeholders for internationalization |
 
 ### Example with Custom Attributes
@@ -119,6 +126,9 @@ You can also include the guarded script from HTML:
   for="password"
   trigger-event="keyup"
   input-throttle="0"
+  rule-matched-alt="Requirement met"
+  rule-unmatched-alt="Requirement not met"
+  announcement="{matched} of {total} requirements met"
   each-delay="100"
   field-valid-class="is-valid"
   field-invalid-class="is-invalid">
@@ -205,21 +215,21 @@ console.log('Current state:', validationList.isValid);
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `--validation-icon-matched` | `"✓"` | Content for the matched state icon |
-| `--validation-icon-unmatched` | `"✗"` | Content for the unmatched state icon |
-| `--validation-icon-size` | `1em` | Size of the validation icons |
-| `--validation-matched-color` | `green` | Color for matched rules |
-| `--validation-unmatched-color` | `red` | Color for unmatched rules |
+| `--rule-matched-icon` | `"✓"` | Content for the matched state icon. Legacy alias: `--validation-icon-matched` |
+| `--rule-unmatched-icon` | `"✗"` | Content for the unmatched state icon. Legacy alias: `--validation-icon-unmatched` |
+| `--rule-icon-size` | `1em` | Size of the validation icons. Legacy alias: `--validation-icon-size` |
+| `--rule-matched-color` | `green` | Color for matched rules. Legacy alias: `--validation-matched-color` |
+| `--rule-unmatched-color` | `red` | Color for unmatched rules. Legacy alias: `--validation-unmatched-color` |
 
 ### Example Custom Styling
 
 ```css
 form-validation-list {
-  --validation-icon-matched: "✅";
-  --validation-icon-unmatched: "❌";
-  --validation-icon-size: 1.2em;
-  --validation-matched-color: #28a745;
-  --validation-unmatched-color: #dc3545;
+  --rule-matched-icon: "✅";
+  --rule-unmatched-icon: "❌";
+  --rule-icon-size: 1.2em;
+  --rule-matched-color: #28a745;
+  --rule-unmatched-color: #dc3545;
 }
 
 form-validation-list ul {
@@ -235,12 +245,19 @@ form-validation-list li {
 
 ## Internationalization
 
-The `validation-message` attribute supports customizable error messages with placeholders for easy internationalization:
+The component exposes separate templates for browser validation messages, live typing announcements, and per-rule hidden state text:
+
+- `validation-message` supports `{matched}` and `{total}` placeholders for native form validation.
+- `announcement` supports `{matched}` and `{total}` placeholders for the live region summary while typing.
+- `rule-matched-alt` and `rule-unmatched-alt` provide localized rule state text when the field is revisited.
 
 ```html
 <!-- Spanish -->
 <form-validation-list
   for="contrasena"
+  announcement="{matched} de {total} criterios cumplidos"
+  rule-matched-alt="Criterio cumplido"
+  rule-unmatched-alt="Criterio pendiente"
   validation-message="Por favor, cumple todos los requisitos ({matched} de {total})">
   <ul>
     <li data-pattern="[A-Z]+">Al menos una letra mayúscula</li>
@@ -252,6 +269,9 @@ The `validation-message` attribute supports customizable error messages with pla
 <!-- French -->
 <form-validation-list
   for="mot-de-passe"
+  announcement="{matched} critères satisfaits sur {total}"
+  rule-matched-alt="Critère satisfait"
+  rule-unmatched-alt="Critère non satisfait"
   validation-message="Veuillez satisfaire à toutes les exigences ({matched} sur {total})">
   <ul>
     <li data-pattern="[A-Z]+">Au moins une lettre majuscule</li>
@@ -267,14 +287,15 @@ The message template uses `{matched}` and `{total}` as placeholders that will be
 
 The component is built with accessibility in mind:
 
-- **ARIA Roles**: The component has `role="list"` and each rule has `role="listitem"`
-- **ARIA Live Regions**: Each rule has `aria-live="polite"` and `aria-atomic="true"` so the full rule text is announced when status changes
-- **ARIA Described-by**: The validation list is automatically associated with the input field via `aria-describedby`, providing context to screen readers
+- **Native List Semantics**: The component preserves the semantics of your existing `ul`/`li` markup
+- **Single Live Region**: A dedicated polite, atomic live region announces the localized summary while the user types
+- **ARIA Described-by**: The validation list is automatically associated with the input field via `aria-describedby`, then temporarily suspended while typing and restored on blur
+- **Localized Rule State**: Each rule gets visually hidden state text in the DOM once the field has a value, which works better with translation tooling than CSS-only alternative text
 - **Existing Descriptions**: If the field already has an `aria-describedby` attribute, the component preserves existing values and appends its own ID
 
 ### Screen Reader Experience
 
-When a user focuses on the input field, screen readers will announce the field label followed by the validation requirements. As users type and rules are matched or unmatched, screen readers will announce the full rule updates because each rule uses `aria-live="polite"` with `aria-atomic="true"`.
+When a user focuses on the input field, screen readers announce the field label followed by the validation requirements. While the user types, the component temporarily suspends the list from `aria-describedby` and instead announces the live summary from the `announcement` template. On blur, the full criteria description is restored so returning to the field reads the latest rule state again.
 
 ## Browser Validation Integration
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can also include the guarded script from HTML:
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `for` | `string` | `""` | **Required.** The ID of the input field to validate |
-| `trigger-event` | `string` | `"input"` | The event to trigger validation on (e.g., "input", "keyup", "change") |
+| `trigger-event` | `string` | `"input"` | The event to trigger validation on (`"input"` or `"blur"`) |
 | `input-throttle` | `number` | `250` | Delay in milliseconds before running validation for `input` events. Set to `0` to disable throttling. |
 | `each-delay` | `number` | `150` | Delay in milliseconds between each rule being classified (creates cascade effect) |
 | `field-invalid-class` | `string` | `"validation-invalid"` | Class to apply to the field when invalid |
@@ -124,7 +124,7 @@ You can also include the guarded script from HTML:
 ```html
 <form-validation-list
   for="password"
-  trigger-event="keyup"
+  trigger-event="input"
   input-throttle="0"
   rule-matched-alt="Requirement met"
   rule-unmatched-alt="Requirement not met"
@@ -336,7 +336,7 @@ If you're migrating from the jQuery version:
 |----------------|----------------------|
 | `data-validation-rules="id"` | `for="id"` |
 | `data-validation-rules-rule="pattern"` | `data-pattern="pattern"` |
-| `trigger_event: "keyup"` | `trigger-event="keyup"` |
+| `trigger_event: "keyup"` | `trigger-event="input"` |
 | `each_delay: 150` | `each-delay="150"` |
 | `field_invalid_class: "class"` | `field-invalid-class="class"` |
 | `field_valid_class: "class"` | `field-valid-class="class"` |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A web component that provides visual validation feedback for form fields using a
 ## TypeScript & Framework Support
 
 - Ships with bundled `.d.ts` definitions so editors and TypeScript builds understand `FormValidationListElement` and `defineFormValidationList`.
-- `for`, `trigger-event`, `each-delay`, and every class-related attribute now reflect between properties and attributes, keeping reactive frameworks and declarative templates in sync with DOM state.
+- `for`, `trigger-event`, `input-throttle`, `each-delay`, and every class-related attribute now reflect between properties and attributes, keeping reactive frameworks and declarative templates in sync with DOM state.
 - An internal `_upgradeProperty` helper captures properties that were assigned before the element upgraded, ensuring early property sets (common in SSR or JSX) are not lost.
 - The `HTMLElementTagNameMap` is augmented so `document.querySelector('form-validation-list')` is strongly typed in TS/JSX projects.
 
@@ -104,6 +104,7 @@ You can also include the guarded script from HTML:
 |-----------|------|---------|-------------|
 | `for` | `string` | `""` | **Required.** The ID of the input field to validate |
 | `trigger-event` | `string` | `"input"` | The event to trigger validation on (e.g., "input", "keyup", "change") |
+| `input-throttle` | `number` | `250` | Delay in milliseconds before running validation for `input` events. Set to `0` to disable throttling. |
 | `each-delay` | `number` | `150` | Delay in milliseconds between each rule being classified (creates cascade effect) |
 | `field-invalid-class` | `string` | `"validation-invalid"` | Class to apply to the field when invalid |
 | `field-valid-class` | `string` | `"validation-valid"` | Class to apply to the field when valid |
@@ -117,6 +118,7 @@ You can also include the guarded script from HTML:
 <form-validation-list
   for="password"
   trigger-event="keyup"
+  input-throttle="0"
   each-delay="100"
   field-valid-class="is-valid"
   field-invalid-class="is-invalid">

--- a/README.md
+++ b/README.md
@@ -156,6 +156,50 @@ You can also include the guarded script from HTML:
 </form-validation-list>
 ```
 
+## Generated Markup
+
+The component automatically enhances your markup with additional elements and IDs:
+
+**Your HTML:**
+
+```html
+<form-validation-list for="password">
+  <ul>
+    <li data-pattern=".{8,}">At least 8 characters</li>
+  </ul>
+</form-validation-list>
+```
+
+**Generated DOM (simplified):**
+
+```html
+<form-validation-list for="password">
+  <ul id="form-validation-list-abc123xyz">
+    <li data-pattern=".{8,}" class="validation-unmatched" aria-atomic="true">
+      <span class="form-validation-list-rule-icon" aria-hidden="true"></span>
+      <span class="form-validation-list-rule-state">Criteria not met </span>
+      At least 8 characters
+    </li>
+  </ul>
+  <span aria-live="polite" aria-atomic="true" class="form-validation-list-live-region"></span>
+</form-validation-list>
+```
+
+**What gets added:**
+
+- **List ID**: A unique ID is assigned to your `<ul>` or `<ol>` element and linked to the input via `aria-describedby`
+- **Rule icon span**: A `<span class="form-validation-list-rule-icon">` is prepended to each rule showing ✓ or ✗
+  - `aria-hidden="true"` prevents screen readers from announcing the icon
+  - Content controlled via the `rule-matched-icon` and `rule-unmatched-icon` attributes or the `--rule-matched-icon` and `--rule-unmatched-icon` CSS properties
+- **Rule state span**: A `<span class="form-validation-list-rule-state">` is inserted after the icon with visually hidden state text
+  - Hidden with `clip: rect(0 0 0 0)` and `position: absolute`
+  - Contains localized state text (default: “Criteria met ” or “Criteria not met ”, configurable via `rule-matched-alt` and `rule-unmatched-alt` attributes)
+  - Only populated when the field has a value (`.has-value` class on the component)
+- **Live region**: A `<span class="form-validation-list-live-region">` with `aria-live="polite"` is added as a sibling to your list
+  - Only updated while typing with `trigger-event="input"`
+  - Cleared on blur and during programmatic validation
+
+
 ## Validation Rules
 
 Rules are defined using the `data-pattern` attribute on any element inside the `<form-validation-list>`. The value should be a valid regular expression pattern.

--- a/README.md
+++ b/README.md
@@ -90,23 +90,39 @@ You can also include the guarded script from HTML:
 
 ## How It Works
 
+### Validation Flow
+
 1. Add a `for` attribute to the `<form-validation-list>` element with the ID of the input field you want to validate
 2. Inside the element, add list items (or any elements) with a `data-pattern` attribute containing a regular expression
-3. As the user types, the component will test the input value against each pattern
-4. While typing, the field temporarily stops referencing the full criteria list via `aria-describedby` to avoid duplicate announcements
-5. A single polite live region announces the localized summary using the `announcement` template
-6. Matched rules get the `validation-matched` class and show a checkmark; unmatched rules get `validation-unmatched` and show an X
-7. Once the field has a value, each rule also includes visually hidden localized state text such as "Criteria met" or "Criteria not met"
-8. On blur, the field's `aria-describedby` is restored so returning to the field reads the full criteria state again
-9. The component uses `setCustomValidity()` to participate in the browser's form validation
+3. Matched rules get the `validation-matched` class and show a checkmark; unmatched rules get `validation-unmatched` and show an X
+4. Once the field has a value, each rule also includes visually hidden localized state text such as "Criteria met" or "Criteria not met"
+5. The component uses `setCustomValidity()` to participate in the browser's form validation
+
+### Trigger Event Behavior
+
+#### With `trigger-event="input"` (default)
+
+- Validation runs on input events with a configurable delay (see `input-throttle`)
+- While typing, the field temporarily stops referencing the full criteria list via `aria-describedby` to avoid duplicate announcements
+- A single polite live region announces the localized summary using the `announcement` template
+- When the user blurs (leaves) the field:
+  - Any pending validation timeouts are cleared to prevent cascading updates
+  - The field's `aria-describedby` is restored after a brief delay so returning to the field reads the full criteria state again
+
+#### With `trigger-event="blur"`
+
+- Validation runs immediately (without throttling) when the user leaves the field
+- The `input-throttle` attribute is ignored
+- No aria-describedby suspension occurs, so the full criteria list remains visible while typing
+- No live region announcements occur during typing
 
 ## Attributes
 
 | Attribute | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `for` | `string` | `""` | **Required.** The ID of the input field to validate |
-| `trigger-event` | `string` | `"input"` | The event to trigger validation on (`"input"` or `"blur"`) |
-| `input-throttle` | `number` | `250` | Delay in milliseconds before running validation for `input` events. Set to `0` to disable throttling. |
+| `trigger-event` | `string` | `"input"` | When to trigger validation: `"input"` (with throttle) or `"blur"` (immediate, no announcements while typing) |
+| `input-throttle` | `number` | `250` | Delay in milliseconds before running validation for `input` events. Only used when `trigger-event="input"`. Set to `0` to disable throttling. |
 | `each-delay` | `number` | `150` | Delay in milliseconds between each rule being classified (creates cascade effect) |
 | `field-invalid-class` | `string` | `"validation-invalid"` | Class to apply to the field when invalid |
 | `field-valid-class` | `string` | `"validation-valid"` | Class to apply to the field when valid |
@@ -288,14 +304,32 @@ The message template uses `{matched}` and `{total}` as placeholders that will be
 The component is built with accessibility in mind:
 
 - **Native List Semantics**: The component preserves the semantics of your existing `ul`/`li` markup
-- **Single Live Region**: A dedicated polite, atomic live region announces the localized summary while the user types
-- **ARIA Described-by**: The validation list is automatically associated with the input field via `aria-describedby`, then temporarily suspended while typing and restored on blur
+- **Smart Live Region**: A dedicated polite, atomic live region announces the localized summary only while the user types with `trigger-event="input"`, keeping screen reader chatter minimal
+- **ARIA Described-by Management**: The validation list is automatically associated with the input field via `aria-describedby`. With `trigger-event="input"`, the list is temporarily suspended while typing to avoid duplicate announcements, then restored on blur. With `trigger-event="blur"`, the list remains visible at all times.
+- **Timeout Cleanup**: Pending validation timeouts are cleared on blur to prevent cascading updates after focus leaves the field
 - **Localized Rule State**: Each rule gets visually hidden state text in the DOM once the field has a value, which works better with translation tooling than CSS-only alternative text
 - **Existing Descriptions**: If the field already has an `aria-describedby` attribute, the component preserves existing values and appends its own ID
 
 ### Screen Reader Experience
 
-When a user focuses on the input field, screen readers announce the field label followed by the validation requirements. While the user types, the component temporarily suspends the list from `aria-describedby` and instead announces the live summary from the `announcement` template. On blur, the full criteria description is restored so returning to the field reads the latest rule state again.
+#### With `trigger-event="input"` (recommended for complex validation)
+
+When a user focuses on the input field, screen readers announce the field label followed by the validation requirements. While the user types:
+- The full validation list is temporarily hidden from the screen reader via aria-describedby suspension
+- A concise live announcement summarizes progress using the `announcement` template (e.g., "Criteria met: 2 of 3")
+- This prevents overwhelming screen reader users with repetitive rule announcements on every keystroke
+
+On blur (when leaving the field):
+- Pending validations are cancelled to prevent stale updates
+- The field's `aria-describedby` is restored after a brief delay
+- Returning to the field will announce the final criteria state
+
+#### With `trigger-event="blur"` (for simple or expensive validation)
+
+- The full validation requirements remain visible via `aria-describedby` at all times
+- Validation only occurs when leaving the field
+- Validation happens immediately without throttling
+- Screen readers will read the full criteria only once on focus, then again on return if changes occurred
 
 ## Browser Validation Integration
 

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -133,6 +133,39 @@
 							"description": "Custom validation message template with {matched} and {total} placeholders for internationalization (default: \"Please match all validation requirements ({matched} of {total})\")",
 							"default": "\"Please match all validation requirements ({matched} of {total})\"",
 							"fieldName": "validationMessage"
+						},
+						{
+							"name": "rule-matched-icon",
+							"type": { "text": "string" },
+							"description": "Icon character for matched rules. Falls back to --rule-matched-icon CSS custom property then \"✓\"",
+							"fieldName": "ruleMatchedIcon"
+						},
+						{
+							"name": "rule-unmatched-icon",
+							"type": { "text": "string" },
+							"description": "Icon character for unmatched rules. Falls back to --rule-unmatched-icon CSS custom property then \"✗\"",
+							"fieldName": "ruleUnmatchedIcon"
+						},
+						{
+							"name": "rule-matched-alt",
+							"type": { "text": "string" },
+							"description": "Localized hidden state text inserted for matched rules once the field has a value (default: \"Criteria met\")",
+							"default": "\"Criteria met\"",
+							"fieldName": "ruleMatchedAlt"
+						},
+						{
+							"name": "rule-unmatched-alt",
+							"type": { "text": "string" },
+							"description": "Localized hidden state text inserted for unmatched rules once the field has a value (default: \"Criteria not met\")",
+							"default": "\"Criteria not met\"",
+							"fieldName": "ruleUnmatchedAlt"
+						},
+						{
+							"name": "announcement",
+							"type": { "text": "string" },
+							"description": "Live region announcement template. Use {matched} and {total} as placeholders (default: \"Criteria met: {matched} of {total}\")",
+							"default": "\"Criteria met: {matched} of {total}\"",
+							"fieldName": "announcement"
 						}
 					],
 					"superclass": {
@@ -142,28 +175,28 @@
 					"customElement": true,
 					"cssProperties": [
 						{
-							"name": "--validation-icon-matched",
-							"description": "Content for the matched state icon",
-							"default": "\"\u2713\""
+							"name": "--rule-matched-icon",
+							"description": "Icon for matched state (default: \"✓\"). Legacy alias: --validation-icon-matched",
+							"default": "\"✓\""
 						},
 						{
-							"name": "--validation-icon-unmatched",
-							"description": "Content for the unmatched state icon",
-							"default": "\"\u2717\""
+							"name": "--rule-unmatched-icon",
+							"description": "Icon for unmatched state (default: \"✗\"). Legacy alias: --validation-icon-unmatched",
+							"default": "\"✗\""
 						},
 						{
-							"name": "--validation-icon-size",
-							"description": "Size of the validation icons",
+							"name": "--rule-icon-size",
+							"description": "Size of the validation icons (default: 1em). Legacy alias: --validation-icon-size",
 							"default": "1em"
 						},
 						{
-							"name": "--validation-matched-color",
-							"description": "Color for matched rules",
+							"name": "--rule-matched-color",
+							"description": "Color for matched rules (default: green). Legacy alias: --validation-matched-color",
 							"default": "green"
 						},
 						{
-							"name": "--validation-unmatched-color",
-							"description": "Color for unmatched rules",
+							"name": "--rule-unmatched-color",
+							"description": "Color for unmatched rules (default: red). Legacy alias: --validation-unmatched-color",
 							"default": "red"
 						}
 					]

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -72,6 +72,15 @@
 							"fieldName": "triggerEvent"
 						},
 						{
+							"name": "input-throttle",
+							"type": {
+								"text": "number"
+							},
+							"description": "Delay in milliseconds before running validation on input events (default: 250)",
+							"default": "250",
+							"fieldName": "inputThrottle"
+						},
+						{
 							"name": "each-delay",
 							"type": {
 								"text": "number"

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -67,7 +67,7 @@
 							"type": {
 								"text": "string"
 							},
-							"description": "The event to trigger validation on (default: \"input\")",
+							"description": "The event to trigger validation on (\"input\" or \"blur\", default: \"input\")",
 							"default": "\"input\"",
 							"fieldName": "triggerEvent"
 						},

--- a/demo/esm.html
+++ b/demo/esm.html
@@ -25,7 +25,7 @@
 		</form-validation-list>
 
 		<script type="module">
-			import { FormValidationListElement } from 'https://esm.sh/@aarongustafson/form-validation-list@2.2.0/form-validation-list.js?bundle&target=es2022';
+			import { FormValidationListElement } from 'https://esm.sh/@aarongustafson/form-validation-list@2.3.0/form-validation-list.js?bundle&target=es2022';
 
 			if (!customElements.get('form-validation-list')) {
 				customElements.define(

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,11 +19,11 @@
 
 			/* Custom styling example */
 			.custom-styled {
-				--validation-icon-matched: '✅';
-				--validation-icon-unmatched: '❌';
-				--validation-icon-size: 1.2em;
-				--validation-matched-color: #28a745;
-				--validation-unmatched-color: #dc3545;
+				--rule-matched-icon: '✅';
+				--rule-unmatched-icon: '❌';
+				--rule-icon-size: 1.2em;
+				--rule-matched-color: #28a745;
+				--rule-unmatched-color: #dc3545;
 			}
 
 			.custom-styled ul {
@@ -194,12 +194,12 @@
 					</p>
 					<div class="code-demo-pair">
 						<pre><code>&lt;style&gt;
-  .custom-styled {
-    --validation-icon-matched: "✅";
-    --validation-icon-unmatched: "❌";
-    --validation-icon-size: 1.2em;
-    --validation-matched-color: #28a745;
-    --validation-unmatched-color: #dc3545;
+	.custom-styled {
+		--rule-matched-icon: "✅";
+		--rule-unmatched-icon: "❌";
+		--rule-icon-size: 1.2em;
+		--rule-matched-color: #28a745;
+		--rule-unmatched-color: #dc3545;
   }
 &lt;/style&gt;
 
@@ -474,20 +474,17 @@
 			<section>
 				<h2>Internationalization (i18n)</h2>
 				<p>
-					The <code>validation-message</code> attribute allows you to
-					customize the error message shown by the browser, including
-					support for other languages.
+					This example localizes the browser validation message, the live
+					summary announcement, and the per-rule hidden state text.
 				</p>
 
 				<div class="demo-section">
 					<h3>Spanish Validation Messages</h3>
 					<p>
 						Using
-						<code
-							>validation-message="Por favor, cumple todos los
-							requisitos ({matched} de {total})"</code
-						>
-						displays the validation error in Spanish.
+						<code>validation-message</code>, <code>announcement</code>,
+						and the <code>rule-*-alt</code> attributes keep the spoken
+						experience localized.
 					</p>
 					<div class="code-demo-pair">
 						<pre><code>&lt;form&gt;
@@ -500,6 +497,9 @@
 
   &lt;form-validation-list
     for="contrasena"
+		announcement="{matched} de {total} criterios cumplidos"
+		rule-matched-alt="Criterio cumplido"
+		rule-unmatched-alt="Criterio pendiente"
     validation-message="Por favor, cumple todos los requisitos ({matched} de {total})"&gt;
     &lt;ul&gt;
       &lt;li data-pattern="[A-Z]+"&gt;Al menos una letra mayúscula&lt;/li&gt;
@@ -524,6 +524,9 @@
 
 								<form-validation-list
 									for="contrasena"
+									announcement="{matched} de {total} criterios cumplidos"
+									rule-matched-alt="Criterio cumplido"
+									rule-unmatched-alt="Criterio pendiente"
 									validation-message="Por favor, cumple todos los requisitos ({matched} de {total})"
 								>
 									<ul>

--- a/form-validation-list.d.ts
+++ b/form-validation-list.d.ts
@@ -5,6 +5,8 @@ export declare class FormValidationListElement extends HTMLElement {
 	set fieldId(value: string | null);
 	get triggerEvent(): string;
 	set triggerEvent(value: string | null);
+	get inputThrottle(): number;
+	set inputThrottle(value: number | string | null);
 	get eachDelay(): number;
 	set eachDelay(value: number | string | null);
 	get fieldInvalidClass(): string;

--- a/form-validation-list.d.ts
+++ b/form-validation-list.d.ts
@@ -17,6 +17,16 @@ export declare class FormValidationListElement extends HTMLElement {
 	set ruleUnmatchedClass(value: string | null);
 	get ruleMatchedClass(): string;
 	set ruleMatchedClass(value: string | null);
+	get ruleMatchedIcon(): string | null;
+	set ruleMatchedIcon(value: string | null);
+	get ruleUnmatchedIcon(): string | null;
+	set ruleUnmatchedIcon(value: string | null);
+	get ruleMatchedAlt(): string;
+	set ruleMatchedAlt(value: string | null);
+	get ruleUnmatchedAlt(): string;
+	set ruleUnmatchedAlt(value: string | null);
+	get announcement(): string;
+	set announcement(value: string | null);
 	get validationMessage(): string | null;
 	set validationMessage(value: string | null);
 	validate(): boolean;

--- a/form-validation-list.js
+++ b/form-validation-list.js
@@ -29,40 +29,40 @@
  * @cssprop --rule-unmatched-color - Color for unmatched rules (default: red). Alias: --validation-unmatched-color
  */
 export class FormValidationListElement extends HTMLElement {
-  static #stylesInjected = false;
-  static #styleId = 'form-validation-list-styles';
-  static #describedByRestoreDelay = 200;
-  static #normalizeTriggerEvent(value) {
-    return value === 'blur' ? 'blur' : 'input';
-  }
+	static #stylesInjected = false;
+	static #styleId = 'form-validation-list-styles';
+	static #describedByRestoreDelay = 200;
+	static #normalizeTriggerEvent(value) {
+		return value === 'blur' ? 'blur' : 'input';
+	}
 
-  static get observedAttributes() {
-    return [
-      'for',
-      'trigger-event',
-      'input-throttle',
-      'each-delay',
-      'field-invalid-class',
-      'field-valid-class',
-      'rule-unmatched-class',
-      'rule-matched-class',
-      'rule-matched-icon',
-      'rule-unmatched-icon',
-      'rule-matched-alt',
-      'rule-unmatched-alt',
-      'announcement',
-      'validation-message',
-    ];
-  }
+	static get observedAttributes() {
+		return [
+			'for',
+			'trigger-event',
+			'input-throttle',
+			'each-delay',
+			'field-invalid-class',
+			'field-valid-class',
+			'rule-unmatched-class',
+			'rule-matched-class',
+			'rule-matched-icon',
+			'rule-unmatched-icon',
+			'rule-matched-alt',
+			'rule-unmatched-alt',
+			'announcement',
+			'validation-message',
+		];
+	}
 
-  static #injectStyles() {
-    if (FormValidationListElement.#stylesInjected) {
-      return;
-    }
+	static #injectStyles() {
+		if (FormValidationListElement.#stylesInjected) {
+			return;
+		}
 
-    const style = document.createElement('style');
-    style.id = FormValidationListElement.#styleId;
-    style.textContent = `
+		const style = document.createElement('style');
+		style.id = FormValidationListElement.#styleId;
+		style.textContent = `
 			form-validation-list {
 				display: block;
 			}
@@ -113,930 +113,930 @@ export class FormValidationListElement extends HTMLElement {
 			}
 		`;
 
-    document.head.appendChild(style);
-    FormValidationListElement.#stylesInjected = true;
-  }
-
-  static #generateId() {
-    return `form-validation-list-${Math.random().toString(36).substr(2, 9)}`;
-  }
-
-  constructor() {
-    super();
-    // Use light DOM instead of shadow DOM
-    this._field = null;
-    this._rules = [];
-    this._validationHandler = null;
-    this._isValid = false;
-    this._validClasses = null;
-    this._invalidClasses = null;
-    this._matchedClasses = null;
-    this._unmatchedClasses = null;
-    this._pendingTimeouts = new Set();
-    this._pendingInputThrottleTimeout = null;
-    this._pendingBlurRestoreTimeout = null;
-    this._currentTriggerEvent = null;
-    this._liveRegion = null;
-    this._blurHandler = null;
-    this._describedBySuspended = false;
-    this._describedByTargetId = null;
-    this._hasValue = false;
-  }
-
-  connectedCallback() {
-    this.__upgradeProperty('for');
-    this.__upgradeProperty('fieldId');
-    this.__upgradeProperty('triggerEvent');
-    this.__upgradeProperty('inputThrottle');
-    this.__upgradeProperty('eachDelay');
-    this.__upgradeProperty('fieldInvalidClass');
-    this.__upgradeProperty('fieldValidClass');
-    this.__upgradeProperty('ruleUnmatchedClass');
-    this.__upgradeProperty('ruleMatchedClass');
-    this.__upgradeProperty('ruleMatchedIcon');
-    this.__upgradeProperty('ruleUnmatchedIcon');
-    this.__upgradeProperty('ruleMatchedAlt');
-    this.__upgradeProperty('ruleUnmatchedAlt');
-    this.__upgradeProperty('announcement');
-    this.__upgradeProperty('validationMessage');
-    FormValidationListElement.#injectStyles();
-    this._setupValidation();
-  }
-
-  disconnectedCallback() {
-    this._cleanup();
-  }
-
-  attributeChangedCallback(name, oldValue, newValue) {
-    if (oldValue === newValue) {
-      return;
-    }
-
-    switch (name) {
-      case 'for':
-        if (this.isConnected) {
-          this._cleanup();
-          this._setupValidation();
-        }
-        break;
-      case 'validation-message':
-        if (this._field) {
-          this._validateField();
-        }
-        break;
-      case 'trigger-event':
-        if (newValue !== null) {
-          const normalizedTriggerEvent =
-            FormValidationListElement.#normalizeTriggerEvent(
-              newValue,
-            );
-          if (newValue !== normalizedTriggerEvent) {
-            this.setAttribute(
-              'trigger-event',
-              normalizedTriggerEvent,
-            );
-            break;
-          }
-        }
-        this.__rebindValidationHandler(oldValue);
-        break;
-      case 'input-throttle':
-        this._clearPendingInputThrottle();
-        if (this._field) {
-          this._validateField();
-        }
-        break;
-      case 'each-delay':
-        this._clearPendingTimeouts();
-        if (this._field) {
-          this._validateField();
-        }
-        break;
-      case 'field-invalid-class':
-        this.__handleFieldClassChange(
-          oldValue,
-          'validation-invalid',
-          '_invalidClasses',
-        );
-        break;
-      case 'field-valid-class':
-        this.__handleFieldClassChange(
-          oldValue,
-          'validation-valid',
-          '_validClasses',
-        );
-        break;
-      case 'rule-unmatched-class':
-        this.__handleRuleClassChange(
-          oldValue,
-          'validation-unmatched',
-          '_unmatchedClasses',
-        );
-        break;
-      case 'rule-matched-class':
-        this.__handleRuleClassChange(
-          oldValue,
-          'validation-matched',
-          '_matchedClasses',
-        );
-        break;
-      case 'rule-matched-icon':
-      case 'rule-unmatched-icon':
-      case 'rule-matched-alt':
-      case 'rule-unmatched-alt':
-        this._updateRulePresentation();
-        break;
-      case 'announcement':
-        // No immediate action needed; next validation pass will use new template
-        break;
-      default:
-        break;
-    }
-  }
-
-  get ['for']() {
-    return this.fieldId;
-  }
-
-  set ['for'](value) {
-    this.fieldId = value;
-  }
-
-  get fieldId() {
-    return this.getAttribute('for');
-  }
-
-  set fieldId(value) {
-    if (value === null || value === undefined || value === '') {
-      this.removeAttribute('for');
-    } else {
-      this.setAttribute('for', String(value));
-    }
-  }
-
-  // Getters for configuration with cached class names
-  get triggerEvent() {
-    return FormValidationListElement.#normalizeTriggerEvent(
-      this.getAttribute('trigger-event'),
-    );
-  }
-
-  set triggerEvent(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value).trim();
-    if (normalized) {
-      this.setAttribute(
-        'trigger-event',
-        FormValidationListElement.#normalizeTriggerEvent(normalized),
-      );
-    } else {
-      this.removeAttribute('trigger-event');
-    }
-  }
-
-  get inputThrottle() {
-    const attrValue = this.getAttribute('input-throttle');
-    if (attrValue === null || attrValue === undefined || attrValue === '') {
-      return 250;
-    }
-    const parsed = Number(attrValue);
-    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 250;
-  }
-
-  set inputThrottle(value) {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed) && parsed >= 0) {
-      this.setAttribute('input-throttle', String(parsed));
-    } else {
-      this.removeAttribute('input-throttle');
-    }
-  }
-
-  get eachDelay() {
-    const attrValue = this.getAttribute('each-delay');
-    if (attrValue === null || attrValue === undefined || attrValue === '') {
-      return 150;
-    }
-    const parsed = Number(attrValue);
-    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 150;
-  }
-
-  set eachDelay(value) {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed) && parsed >= 0) {
-      this.setAttribute('each-delay', String(parsed));
-    } else {
-      this.removeAttribute('each-delay');
-    }
-  }
-
-  get fieldInvalidClass() {
-    if (this._invalidClasses === null) {
-      const attr = this.getAttribute('field-invalid-class');
-      this._invalidClasses = attr || 'validation-invalid';
-    }
-    return this._invalidClasses;
-  }
-
-  set fieldInvalidClass(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value).trim();
-    if (normalized) {
-      this.setAttribute('field-invalid-class', normalized);
-    } else {
-      this.removeAttribute('field-invalid-class');
-    }
-  }
-
-  get fieldValidClass() {
-    if (this._validClasses === null) {
-      const attr = this.getAttribute('field-valid-class');
-      this._validClasses = attr || 'validation-valid';
-    }
-    return this._validClasses;
-  }
-
-  set fieldValidClass(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value).trim();
-    if (normalized) {
-      this.setAttribute('field-valid-class', normalized);
-    } else {
-      this.removeAttribute('field-valid-class');
-    }
-  }
-
-  get ruleUnmatchedClass() {
-    if (this._unmatchedClasses === null) {
-      const attr = this.getAttribute('rule-unmatched-class');
-      this._unmatchedClasses = attr || 'validation-unmatched';
-    }
-    return this._unmatchedClasses;
-  }
-
-  set ruleUnmatchedClass(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value).trim();
-    if (normalized) {
-      this.setAttribute('rule-unmatched-class', normalized);
-    } else {
-      this.removeAttribute('rule-unmatched-class');
-    }
-  }
-
-  get ruleMatchedClass() {
-    if (this._matchedClasses === null) {
-      const attr = this.getAttribute('rule-matched-class');
-      this._matchedClasses = attr || 'validation-matched';
-    }
-    return this._matchedClasses;
-  }
-
-  set ruleMatchedClass(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value).trim();
-    if (normalized) {
-      this.setAttribute('rule-matched-class', normalized);
-    } else {
-      this.removeAttribute('rule-matched-class');
-    }
-  }
-
-  get validationMessage() {
-    return this.getAttribute('validation-message');
-  }
-
-  set validationMessage(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('validation-message', normalized);
-    } else {
-      this.removeAttribute('validation-message');
-    }
-  }
-
-  get ruleMatchedIcon() {
-    return this.getAttribute('rule-matched-icon');
-  }
-
-  set ruleMatchedIcon(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('rule-matched-icon', normalized);
-    } else {
-      this.removeAttribute('rule-matched-icon');
-    }
-  }
-
-  get ruleUnmatchedIcon() {
-    return this.getAttribute('rule-unmatched-icon');
-  }
-
-  set ruleUnmatchedIcon(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('rule-unmatched-icon', normalized);
-    } else {
-      this.removeAttribute('rule-unmatched-icon');
-    }
-  }
-
-  get ruleMatchedAlt() {
-    const attr = this.getAttribute('rule-matched-alt');
-    return attr !== null ? attr : 'Criteria met';
-  }
-
-  set ruleMatchedAlt(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('rule-matched-alt', normalized);
-    } else {
-      this.removeAttribute('rule-matched-alt');
-    }
-  }
-
-  get ruleUnmatchedAlt() {
-    const attr = this.getAttribute('rule-unmatched-alt');
-    return attr !== null ? attr : 'Criteria not met';
-  }
-
-  set ruleUnmatchedAlt(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('rule-unmatched-alt', normalized);
-    } else {
-      this.removeAttribute('rule-unmatched-alt');
-    }
-  }
-
-  get announcement() {
-    const attr = this.getAttribute('announcement');
-    return attr !== null ? attr : 'Criteria met: {matched} of {total}';
-  }
-
-  set announcement(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('announcement', normalized);
-    } else {
-      this.removeAttribute('announcement');
-    }
-  }
-
-  __upgradeProperty(prop) {
-    if (Object.prototype.hasOwnProperty.call(this, prop)) {
-      const value = this[prop];
-      delete this[prop];
-      this[prop] = value;
-    }
-  }
-
-  _setupValidation() {
-    this._clearPendingTimeouts();
-    const fieldId = this.fieldId;
-    if (!fieldId) return;
-
-    // Find the field
-    this._field = document.getElementById(fieldId);
-    if (!this._field) {
-      console.warn(
-        `form-validation-list: Could not find field with id="${fieldId}"`,
-      );
-      return;
-    }
-
-    this._isValid = false;
-
-    // Find all rules (elements with data-pattern attribute)
-    this._rules = Array.from(this.querySelectorAll('[data-pattern]')).map(
-      (element) => ({
-        element,
-        pattern: element.getAttribute('data-pattern'),
-        regex: new RegExp(element.getAttribute('data-pattern')),
-      }),
-    );
-
-    if (this._rules.length === 0) {
-      console.warn(
-        'form-validation-list: No rules found with data-pattern attribute',
-      );
-      return;
-    }
-
-    // Set up ARIA relationship
-    this._setupAccessibility();
-
-    // Only add aria-atomic to list items; live announcements go through the live region
-    this._rules.forEach(({ element }) => {
-      FormValidationListElement.#ensureRulePresentation(element);
-      element.setAttribute('aria-atomic', 'true');
-    });
-
-    // Create the visually-hidden live region as a sibling to the list within the component.
-    if (!this._liveRegion) {
-      this._liveRegion = document.createElement('span');
-      this._liveRegion.setAttribute('aria-live', 'polite');
-      this._liveRegion.setAttribute('aria-atomic', 'true');
-      this._liveRegion.className = 'form-validation-list-live-region';
-      this.appendChild(this._liveRegion);
-    }
-
-    // Sync icon glyphs and rule state text for this instance
-    this._updateRulePresentation();
-
-    // Attach blur handler to restore aria-describedby
-    if (!this._blurHandler) {
-      this._blurHandler = () => {
-        this._clearPendingBlurRestore();
-        this._pendingBlurRestoreTimeout = setTimeout(() => {
-          this._pendingBlurRestoreTimeout = null;
-          this._restoreDescribedBy();
-        }, FormValidationListElement.#describedByRestoreDelay);
-        if (this._liveRegion) {
-          this._liveRegion.textContent = '';
-        }
-      };
-      this._field.addEventListener('blur', this._blurHandler);
-    }
-
-    // Create validation handler
-    if (!this._validationHandler) {
-      this._validationHandler = () => {
-        this._scheduleValidation();
-      };
-    }
-
-    // Attach event listener
-    this._currentTriggerEvent = this.triggerEvent;
-    this._field.addEventListener(
-      this._currentTriggerEvent,
-      this._validationHandler,
-    );
-
-    // Run initial validation if field has a value
-    if (this._field.value) {
-      this._validateField();
-    }
-  }
-
-  _setupAccessibility() {
-    if (!this._field) return;
-
-    const describedByTarget = this.querySelector('ul, ol') || this;
-    if (!describedByTarget.id) {
-      describedByTarget.id = FormValidationListElement.#generateId();
-    }
-    const listId = describedByTarget.id;
-    this._describedByTargetId = listId;
-
-    // Add this list to the field's aria-describedby
-    const existingDescribedBy =
-      this._field.getAttribute('aria-describedby');
-    if (existingDescribedBy) {
-      const describedByIds =
-        FormValidationListElement.#parseIdRefs(existingDescribedBy);
-      if (!describedByIds.includes(listId)) {
-        describedByIds.push(listId);
-        this._field.setAttribute(
-          'aria-describedby',
-          describedByIds.join(' '),
-        );
-      }
-    } else {
-      this._field.setAttribute('aria-describedby', listId);
-    }
-  }
-
-  _suspendDescribedBy() {
-    if (
-      this._describedBySuspended ||
-      !this._field ||
-      !this._describedByTargetId
-    )
-      return;
-    this._removeOwnDescribedBy();
-    this._describedBySuspended = true;
-  }
-
-  _restoreDescribedBy() {
-    this._clearPendingBlurRestore();
-    if (
-      !this._describedBySuspended ||
-      !this._field ||
-      !this._describedByTargetId
-    )
-      return;
-    const current = this._field.getAttribute('aria-describedby');
-    if (current) {
-      const ids = FormValidationListElement.#parseIdRefs(current);
-      if (!ids.includes(this._describedByTargetId)) {
-        ids.push(this._describedByTargetId);
-        this._field.setAttribute('aria-describedby', ids.join(' '));
-      }
-    } else {
-      this._field.setAttribute(
-        'aria-describedby',
-        this._describedByTargetId,
-      );
-    }
-    this._describedBySuspended = false;
-  }
-
-  _removeOwnDescribedBy(field = this._field) {
-    if (!field || !this._describedByTargetId) return;
-    const current = field.getAttribute('aria-describedby');
-    if (!current) return;
-    const ids = FormValidationListElement.#parseIdRefs(current).filter(
-      (id) => id !== this._describedByTargetId,
-    );
-    if (ids.length > 0) {
-      field.setAttribute('aria-describedby', ids.join(' '));
-    } else {
-      field.removeAttribute('aria-describedby');
-    }
-  }
-
-  static #parseIdRefs(value) {
-    if (!value) return [];
-    return value.trim().split(/\s+/).filter(Boolean);
-  }
-
-  static #expandCountTemplate(template, matched, total) {
-    return String(template)
-      .replace(/\{matched\}/g, String(matched))
-      .replace(/\{total\}/g, String(total));
-  }
-
-  static #ensureRulePresentation(element) {
-    let iconElement = element.querySelector(
-      ':scope > .form-validation-list-rule-icon',
-    );
-    if (!iconElement) {
-      iconElement = document.createElement('span');
-      iconElement.className = 'form-validation-list-rule-icon';
-      iconElement.setAttribute('aria-hidden', 'true');
-      element.prepend(iconElement);
-    }
-
-    let stateElement = element.querySelector(
-      ':scope > .form-validation-list-rule-state',
-    );
-    if (!stateElement) {
-      stateElement = document.createElement('span');
-      stateElement.className = 'form-validation-list-rule-state';
-      iconElement.insertAdjacentElement('afterend', stateElement);
-    }
-
-    return { iconElement, stateElement };
-  }
-
-  _updateRulePresentation() {
-    if (this.ruleMatchedIcon) {
-      this.style.setProperty(
-        '--form-validation-list-rule-matched-icon',
-        JSON.stringify(this.ruleMatchedIcon),
-      );
-    } else {
-      this.style.removeProperty(
-        '--form-validation-list-rule-matched-icon',
-      );
-    }
-
-    if (this.ruleUnmatchedIcon) {
-      this.style.setProperty(
-        '--form-validation-list-rule-unmatched-icon',
-        JSON.stringify(this.ruleUnmatchedIcon),
-      );
-    } else {
-      this.style.removeProperty(
-        '--form-validation-list-rule-unmatched-icon',
-      );
-    }
-
-    for (let i = 0; i < this._rules.length; i++) {
-      const { element } = this._rules[i];
-      const { stateElement } =
-        FormValidationListElement.#ensureRulePresentation(element);
-      const isMatched = element.classList.contains(this.ruleMatchedClass);
-      stateElement.textContent = this._hasValue
-        ? `${isMatched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
-        : '';
-    }
-  }
-
-  __handleFieldClassChange(oldValue, defaultClass, cacheKey) {
-    const previousClass =
-      oldValue === null ? defaultClass : oldValue || null;
-    this[cacheKey] = null;
-    if (this._field && previousClass) {
-      this._field.classList.remove(previousClass);
-    }
-    if (this._field) {
-      this._validateField();
-    }
-  }
-
-  __handleRuleClassChange(oldValue, defaultClass, cacheKey) {
-    const previousClass =
-      oldValue === null ? defaultClass : oldValue || null;
-    this[cacheKey] = null;
-    if (previousClass) {
-      for (let i = 0; i < this._rules.length; i++) {
-        this._rules[i].element.classList.remove(previousClass);
-      }
-    }
-    if (this._field) {
-      this._validateField();
-    }
-  }
-
-  __rebindValidationHandler(oldValue) {
-    if (!this._field || !this._validationHandler) {
-      return;
-    }
-    this._clearPendingInputThrottle();
-    const previousEvent = this._currentTriggerEvent || oldValue || 'input';
-    const nextEvent = this.triggerEvent;
-    if (previousEvent === nextEvent) {
-      return;
-    }
-    this._field.removeEventListener(previousEvent, this._validationHandler);
-    this._currentTriggerEvent = nextEvent;
-    this._field.addEventListener(nextEvent, this._validationHandler);
-  }
-
-  _clearPendingTimeouts() {
-    if (!this._pendingTimeouts.size) {
-      return;
-    }
-    for (const timeoutId of this._pendingTimeouts) {
-      clearTimeout(timeoutId);
-    }
-    this._pendingTimeouts.clear();
-  }
-
-  _clearPendingInputThrottle() {
-    if (this._pendingInputThrottleTimeout === null) {
-      return;
-    }
-    clearTimeout(this._pendingInputThrottleTimeout);
-    this._pendingInputThrottleTimeout = null;
-  }
-
-  _clearPendingBlurRestore() {
-    if (this._pendingBlurRestoreTimeout === null) {
-      return;
-    }
-    clearTimeout(this._pendingBlurRestoreTimeout);
-    this._pendingBlurRestoreTimeout = null;
-  }
-
-  _scheduleValidation() {
-    if (!this._field) {
-      return;
-    }
-
-    const listenerType = this._currentTriggerEvent || this.triggerEvent;
-    if (listenerType !== 'input') {
-      this._validateField();
-      return;
-    }
-
-    // Cancel pending restore when typing resumes.
-    this._clearPendingBlurRestore();
-
-    // Suspend aria-describedby as soon as the user starts typing
-    this._suspendDescribedBy();
-
-    const throttleDelay = this.inputThrottle;
-    if (throttleDelay <= 0) {
-      this._validateField();
-      return;
-    }
-
-    this._clearPendingInputThrottle();
-    this._pendingInputThrottleTimeout = setTimeout(() => {
-      this._pendingInputThrottleTimeout = null;
-      this._validateField();
-    }, throttleDelay);
-  }
-
-  _validateField() {
-    if (!this._field) return;
-
-    this._clearPendingTimeouts();
-
-    const value = this._field.value;
-    const rulesCount = this._rules.length;
-    let matchedRules = 0;
-    const delay = this.eachDelay;
-
-    // Track whether the field has a value to expose localized rule state text
-    const hasValue = value.length > 0;
-    if (hasValue !== this._hasValue) {
-      this._hasValue = hasValue;
-      this.classList.toggle('has-value', hasValue);
-    }
-
-    // Validate each rule
-    for (let i = 0; i < rulesCount; i++) {
-      const { element, regex } = this._rules[i];
-      const matched = regex.test(value);
-
-      if (matched) {
-        matchedRules++;
-      }
-
-      const applyClasses = () => {
-        this._toggleMatchedClasses(element, matched);
-      };
-
-      // Apply class changes with delay for visual cascade effect
-      if (delay > 0) {
-        const timeoutId = setTimeout(() => {
-          this._pendingTimeouts.delete(timeoutId);
-          applyClasses();
-        }, i * delay);
-        this._pendingTimeouts.add(timeoutId);
-      } else {
-        applyClasses();
-      }
-    }
-
-    // Update field validity
-    const isValid = matchedRules === rulesCount;
-    this._isValid = isValid;
-
-    // Cache class names for performance
-    const validClass = this.fieldValidClass;
-    const invalidClass = this.fieldInvalidClass;
-
-    // Update field classes
-    const fieldClassList = this._field.classList;
-    if (isValid) {
-      fieldClassList.add(validClass);
-      fieldClassList.remove(invalidClass);
-    } else {
-      fieldClassList.add(invalidClass);
-      fieldClassList.remove(validClass);
-    }
-
-    // Update live region with summary announcement
-    if (this._liveRegion) {
-      this._liveRegion.textContent =
-        FormValidationListElement.#expandCountTemplate(
-          this.announcement,
-          matchedRules,
-          rulesCount,
-        );
-    }
-
-    // Integrate with browser validation
-    this._updateFieldValidity(isValid, matchedRules);
-
-    // Fire custom event
-    this.dispatchEvent(
-      new CustomEvent('form-validation-list:validated', {
-        bubbles: true,
-        composed: true,
-        detail: {
-          isValid,
-          matchedRules,
-          totalRules: rulesCount,
-          field: this._field,
-        },
-      }),
-    );
-  }
-
-  _toggleMatchedClasses(element, matched) {
-    const { stateElement } =
-      FormValidationListElement.#ensureRulePresentation(element);
-    const classList = element.classList;
-    if (matched) {
-      classList.add(this.ruleMatchedClass);
-      classList.remove(this.ruleUnmatchedClass);
-    } else {
-      classList.add(this.ruleUnmatchedClass);
-      classList.remove(this.ruleMatchedClass);
-    }
-    stateElement.textContent = this._hasValue
-      ? `${matched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
-      : '';
-  }
-
-  _updateFieldValidity(isValid, matchedRules) {
-    if (!this._field || !this._field.setCustomValidity) return;
-
-    if (isValid) {
-      this._field.setCustomValidity('');
-    } else {
-      const template =
-        this.validationMessage ||
-        'Please match all validation requirements ({matched} of {total})';
-      const message = FormValidationListElement.#expandCountTemplate(
-        template,
-        matchedRules,
-        this._rules.length,
-      );
-      this._field.setCustomValidity(message);
-    }
-  }
-
-  _cleanup() {
-    this._clearPendingBlurRestore();
-    this._clearPendingInputThrottle();
-    this._clearPendingTimeouts();
-
-    // Remove event listeners
-    if (this._field && this._validationHandler) {
-      const listenerType =
-        this._currentTriggerEvent || this.triggerEvent || 'input';
-      this._field.removeEventListener(
-        listenerType,
-        this._validationHandler,
-      );
-    }
-    if (this._field && this._blurHandler) {
-      this._field.removeEventListener('blur', this._blurHandler);
-    }
-
-    // Remove this element from the field's aria-describedby on cleanup
-    this._removeOwnDescribedBy();
-
-    // Clear custom validity
-    if (this._field && this._field.setCustomValidity) {
-      this._field.setCustomValidity('');
-    }
-
-    // Remove classes from field
-    if (this._field) {
-      this._field.classList.remove(
-        this.fieldValidClass,
-        this.fieldInvalidClass,
-      );
-    }
-
-    // Remove classes from rules
-    const rulesCount = this._rules.length;
-    const matchedClass = this.ruleMatchedClass;
-    const unmatchedClass = this.ruleUnmatchedClass;
-
-    for (let i = 0; i < rulesCount; i++) {
-      this._rules[i].element.classList.remove(
-        matchedClass,
-        unmatchedClass,
-      );
-    }
-
-    // Remove live region
-    if (this._liveRegion && this._liveRegion.parentNode) {
-      this._liveRegion.remove();
-    }
-
-    // Remove has-value class
-    this.classList.remove('has-value');
-    this.style.removeProperty('--form-validation-list-rule-matched-icon');
-    this.style.removeProperty('--form-validation-list-rule-unmatched-icon');
-
-    this._field = null;
-    this._rules = [];
-    this._validationHandler = null;
-    this._blurHandler = null;
-    this._liveRegion = null;
-    this._pendingBlurRestoreTimeout = null;
-    this._validClasses = null;
-    this._invalidClasses = null;
-    this._matchedClasses = null;
-    this._unmatchedClasses = null;
-    this._currentTriggerEvent = null;
-    this._describedBySuspended = false;
-    this._describedByTargetId = null;
-    this._hasValue = false;
-    this._isValid = false;
-  }
-
-  /**
-   * Manually trigger validation
-   * @public
-   */
-  validate() {
-    this._validateField();
-    return this._isValid;
-  }
-
-  /**
-   * Get the current validation state
-   * @public
-   * @returns {boolean} Whether all rules are currently matched
-   */
-  get isValid() {
-    return this._isValid;
-  }
+		document.head.appendChild(style);
+		FormValidationListElement.#stylesInjected = true;
+	}
+
+	static #generateId() {
+		return `form-validation-list-${Math.random().toString(36).substr(2, 9)}`;
+	}
+
+	constructor() {
+		super();
+		// Use light DOM instead of shadow DOM
+		this._field = null;
+		this._rules = [];
+		this._validationHandler = null;
+		this._isValid = false;
+		this._validClasses = null;
+		this._invalidClasses = null;
+		this._matchedClasses = null;
+		this._unmatchedClasses = null;
+		this._pendingTimeouts = new Set();
+		this._pendingInputThrottleTimeout = null;
+		this._pendingBlurRestoreTimeout = null;
+		this._currentTriggerEvent = null;
+		this._liveRegion = null;
+		this._blurHandler = null;
+		this._describedBySuspended = false;
+		this._describedByTargetId = null;
+		this._hasValue = false;
+	}
+
+	connectedCallback() {
+		this.__upgradeProperty('for');
+		this.__upgradeProperty('fieldId');
+		this.__upgradeProperty('triggerEvent');
+		this.__upgradeProperty('inputThrottle');
+		this.__upgradeProperty('eachDelay');
+		this.__upgradeProperty('fieldInvalidClass');
+		this.__upgradeProperty('fieldValidClass');
+		this.__upgradeProperty('ruleUnmatchedClass');
+		this.__upgradeProperty('ruleMatchedClass');
+		this.__upgradeProperty('ruleMatchedIcon');
+		this.__upgradeProperty('ruleUnmatchedIcon');
+		this.__upgradeProperty('ruleMatchedAlt');
+		this.__upgradeProperty('ruleUnmatchedAlt');
+		this.__upgradeProperty('announcement');
+		this.__upgradeProperty('validationMessage');
+		FormValidationListElement.#injectStyles();
+		this._setupValidation();
+	}
+
+	disconnectedCallback() {
+		this._cleanup();
+	}
+
+	attributeChangedCallback(name, oldValue, newValue) {
+		if (oldValue === newValue) {
+			return;
+		}
+
+		switch (name) {
+			case 'for':
+				if (this.isConnected) {
+					this._cleanup();
+					this._setupValidation();
+				}
+				break;
+			case 'validation-message':
+				if (this._field) {
+					this._validateField();
+				}
+				break;
+			case 'trigger-event':
+				if (newValue !== null) {
+					const normalizedTriggerEvent =
+						FormValidationListElement.#normalizeTriggerEvent(
+							newValue,
+						);
+					if (newValue !== normalizedTriggerEvent) {
+						this.setAttribute(
+							'trigger-event',
+							normalizedTriggerEvent,
+						);
+						break;
+					}
+				}
+				this.__rebindValidationHandler(oldValue);
+				break;
+			case 'input-throttle':
+				this._clearPendingInputThrottle();
+				if (this._field) {
+					this._validateField();
+				}
+				break;
+			case 'each-delay':
+				this._clearPendingTimeouts();
+				if (this._field) {
+					this._validateField();
+				}
+				break;
+			case 'field-invalid-class':
+				this.__handleFieldClassChange(
+					oldValue,
+					'validation-invalid',
+					'_invalidClasses',
+				);
+				break;
+			case 'field-valid-class':
+				this.__handleFieldClassChange(
+					oldValue,
+					'validation-valid',
+					'_validClasses',
+				);
+				break;
+			case 'rule-unmatched-class':
+				this.__handleRuleClassChange(
+					oldValue,
+					'validation-unmatched',
+					'_unmatchedClasses',
+				);
+				break;
+			case 'rule-matched-class':
+				this.__handleRuleClassChange(
+					oldValue,
+					'validation-matched',
+					'_matchedClasses',
+				);
+				break;
+			case 'rule-matched-icon':
+			case 'rule-unmatched-icon':
+			case 'rule-matched-alt':
+			case 'rule-unmatched-alt':
+				this._updateRulePresentation();
+				break;
+			case 'announcement':
+				// No immediate action needed; next validation pass will use new template
+				break;
+			default:
+				break;
+		}
+	}
+
+	get ['for']() {
+		return this.fieldId;
+	}
+
+	set ['for'](value) {
+		this.fieldId = value;
+	}
+
+	get fieldId() {
+		return this.getAttribute('for');
+	}
+
+	set fieldId(value) {
+		if (value === null || value === undefined || value === '') {
+			this.removeAttribute('for');
+		} else {
+			this.setAttribute('for', String(value));
+		}
+	}
+
+	// Getters for configuration with cached class names
+	get triggerEvent() {
+		return FormValidationListElement.#normalizeTriggerEvent(
+			this.getAttribute('trigger-event'),
+		);
+	}
+
+	set triggerEvent(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value).trim();
+		if (normalized) {
+			this.setAttribute(
+				'trigger-event',
+				FormValidationListElement.#normalizeTriggerEvent(normalized),
+			);
+		} else {
+			this.removeAttribute('trigger-event');
+		}
+	}
+
+	get inputThrottle() {
+		const attrValue = this.getAttribute('input-throttle');
+		if (attrValue === null || attrValue === undefined || attrValue === '') {
+			return 250;
+		}
+		const parsed = Number(attrValue);
+		return Number.isFinite(parsed) && parsed >= 0 ? parsed : 250;
+	}
+
+	set inputThrottle(value) {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed) && parsed >= 0) {
+			this.setAttribute('input-throttle', String(parsed));
+		} else {
+			this.removeAttribute('input-throttle');
+		}
+	}
+
+	get eachDelay() {
+		const attrValue = this.getAttribute('each-delay');
+		if (attrValue === null || attrValue === undefined || attrValue === '') {
+			return 150;
+		}
+		const parsed = Number(attrValue);
+		return Number.isFinite(parsed) && parsed >= 0 ? parsed : 150;
+	}
+
+	set eachDelay(value) {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed) && parsed >= 0) {
+			this.setAttribute('each-delay', String(parsed));
+		} else {
+			this.removeAttribute('each-delay');
+		}
+	}
+
+	get fieldInvalidClass() {
+		if (this._invalidClasses === null) {
+			const attr = this.getAttribute('field-invalid-class');
+			this._invalidClasses = attr || 'validation-invalid';
+		}
+		return this._invalidClasses;
+	}
+
+	set fieldInvalidClass(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value).trim();
+		if (normalized) {
+			this.setAttribute('field-invalid-class', normalized);
+		} else {
+			this.removeAttribute('field-invalid-class');
+		}
+	}
+
+	get fieldValidClass() {
+		if (this._validClasses === null) {
+			const attr = this.getAttribute('field-valid-class');
+			this._validClasses = attr || 'validation-valid';
+		}
+		return this._validClasses;
+	}
+
+	set fieldValidClass(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value).trim();
+		if (normalized) {
+			this.setAttribute('field-valid-class', normalized);
+		} else {
+			this.removeAttribute('field-valid-class');
+		}
+	}
+
+	get ruleUnmatchedClass() {
+		if (this._unmatchedClasses === null) {
+			const attr = this.getAttribute('rule-unmatched-class');
+			this._unmatchedClasses = attr || 'validation-unmatched';
+		}
+		return this._unmatchedClasses;
+	}
+
+	set ruleUnmatchedClass(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value).trim();
+		if (normalized) {
+			this.setAttribute('rule-unmatched-class', normalized);
+		} else {
+			this.removeAttribute('rule-unmatched-class');
+		}
+	}
+
+	get ruleMatchedClass() {
+		if (this._matchedClasses === null) {
+			const attr = this.getAttribute('rule-matched-class');
+			this._matchedClasses = attr || 'validation-matched';
+		}
+		return this._matchedClasses;
+	}
+
+	set ruleMatchedClass(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value).trim();
+		if (normalized) {
+			this.setAttribute('rule-matched-class', normalized);
+		} else {
+			this.removeAttribute('rule-matched-class');
+		}
+	}
+
+	get validationMessage() {
+		return this.getAttribute('validation-message');
+	}
+
+	set validationMessage(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('validation-message', normalized);
+		} else {
+			this.removeAttribute('validation-message');
+		}
+	}
+
+	get ruleMatchedIcon() {
+		return this.getAttribute('rule-matched-icon');
+	}
+
+	set ruleMatchedIcon(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-matched-icon', normalized);
+		} else {
+			this.removeAttribute('rule-matched-icon');
+		}
+	}
+
+	get ruleUnmatchedIcon() {
+		return this.getAttribute('rule-unmatched-icon');
+	}
+
+	set ruleUnmatchedIcon(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-unmatched-icon', normalized);
+		} else {
+			this.removeAttribute('rule-unmatched-icon');
+		}
+	}
+
+	get ruleMatchedAlt() {
+		const attr = this.getAttribute('rule-matched-alt');
+		return attr !== null ? attr : 'Criteria met';
+	}
+
+	set ruleMatchedAlt(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-matched-alt', normalized);
+		} else {
+			this.removeAttribute('rule-matched-alt');
+		}
+	}
+
+	get ruleUnmatchedAlt() {
+		const attr = this.getAttribute('rule-unmatched-alt');
+		return attr !== null ? attr : 'Criteria not met';
+	}
+
+	set ruleUnmatchedAlt(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-unmatched-alt', normalized);
+		} else {
+			this.removeAttribute('rule-unmatched-alt');
+		}
+	}
+
+	get announcement() {
+		const attr = this.getAttribute('announcement');
+		return attr !== null ? attr : 'Criteria met: {matched} of {total}';
+	}
+
+	set announcement(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('announcement', normalized);
+		} else {
+			this.removeAttribute('announcement');
+		}
+	}
+
+	__upgradeProperty(prop) {
+		if (Object.prototype.hasOwnProperty.call(this, prop)) {
+			const value = this[prop];
+			delete this[prop];
+			this[prop] = value;
+		}
+	}
+
+	_setupValidation() {
+		this._clearPendingTimeouts();
+		const fieldId = this.fieldId;
+		if (!fieldId) return;
+
+		// Find the field
+		this._field = document.getElementById(fieldId);
+		if (!this._field) {
+			console.warn(
+				`form-validation-list: Could not find field with id="${fieldId}"`,
+			);
+			return;
+		}
+
+		this._isValid = false;
+
+		// Find all rules (elements with data-pattern attribute)
+		this._rules = Array.from(this.querySelectorAll('[data-pattern]')).map(
+			(element) => ({
+				element,
+				pattern: element.getAttribute('data-pattern'),
+				regex: new RegExp(element.getAttribute('data-pattern')),
+			}),
+		);
+
+		if (this._rules.length === 0) {
+			console.warn(
+				'form-validation-list: No rules found with data-pattern attribute',
+			);
+			return;
+		}
+
+		// Set up ARIA relationship
+		this._setupAccessibility();
+
+		// Only add aria-atomic to list items; live announcements go through the live region
+		this._rules.forEach(({ element }) => {
+			FormValidationListElement.#ensureRulePresentation(element);
+			element.setAttribute('aria-atomic', 'true');
+		});
+
+		// Create the visually-hidden live region as a sibling to the list within the component.
+		if (!this._liveRegion) {
+			this._liveRegion = document.createElement('span');
+			this._liveRegion.setAttribute('aria-live', 'polite');
+			this._liveRegion.setAttribute('aria-atomic', 'true');
+			this._liveRegion.className = 'form-validation-list-live-region';
+			this.appendChild(this._liveRegion);
+		}
+
+		// Sync icon glyphs and rule state text for this instance
+		this._updateRulePresentation();
+
+		// Attach blur handler to restore aria-describedby
+		if (!this._blurHandler) {
+			this._blurHandler = () => {
+				this._clearPendingBlurRestore();
+				this._pendingBlurRestoreTimeout = setTimeout(() => {
+					this._pendingBlurRestoreTimeout = null;
+					this._restoreDescribedBy();
+				}, FormValidationListElement.#describedByRestoreDelay);
+				if (this._liveRegion) {
+					this._liveRegion.textContent = '';
+				}
+			};
+			this._field.addEventListener('blur', this._blurHandler);
+		}
+
+		// Create validation handler
+		if (!this._validationHandler) {
+			this._validationHandler = () => {
+				this._scheduleValidation();
+			};
+		}
+
+		// Attach event listener
+		this._currentTriggerEvent = this.triggerEvent;
+		this._field.addEventListener(
+			this._currentTriggerEvent,
+			this._validationHandler,
+		);
+
+		// Run initial validation if field has a value
+		if (this._field.value) {
+			this._validateField();
+		}
+	}
+
+	_setupAccessibility() {
+		if (!this._field) return;
+
+		const describedByTarget = this.querySelector('ul, ol') || this;
+		if (!describedByTarget.id) {
+			describedByTarget.id = FormValidationListElement.#generateId();
+		}
+		const listId = describedByTarget.id;
+		this._describedByTargetId = listId;
+
+		// Add this list to the field's aria-describedby
+		const existingDescribedBy =
+			this._field.getAttribute('aria-describedby');
+		if (existingDescribedBy) {
+			const describedByIds =
+				FormValidationListElement.#parseIdRefs(existingDescribedBy);
+			if (!describedByIds.includes(listId)) {
+				describedByIds.push(listId);
+				this._field.setAttribute(
+					'aria-describedby',
+					describedByIds.join(' '),
+				);
+			}
+		} else {
+			this._field.setAttribute('aria-describedby', listId);
+		}
+	}
+
+	_suspendDescribedBy() {
+		if (
+			this._describedBySuspended ||
+			!this._field ||
+			!this._describedByTargetId
+		)
+			return;
+		this._removeOwnDescribedBy();
+		this._describedBySuspended = true;
+	}
+
+	_restoreDescribedBy() {
+		this._clearPendingBlurRestore();
+		if (
+			!this._describedBySuspended ||
+			!this._field ||
+			!this._describedByTargetId
+		)
+			return;
+		const current = this._field.getAttribute('aria-describedby');
+		if (current) {
+			const ids = FormValidationListElement.#parseIdRefs(current);
+			if (!ids.includes(this._describedByTargetId)) {
+				ids.push(this._describedByTargetId);
+				this._field.setAttribute('aria-describedby', ids.join(' '));
+			}
+		} else {
+			this._field.setAttribute(
+				'aria-describedby',
+				this._describedByTargetId,
+			);
+		}
+		this._describedBySuspended = false;
+	}
+
+	_removeOwnDescribedBy(field = this._field) {
+		if (!field || !this._describedByTargetId) return;
+		const current = field.getAttribute('aria-describedby');
+		if (!current) return;
+		const ids = FormValidationListElement.#parseIdRefs(current).filter(
+			(id) => id !== this._describedByTargetId,
+		);
+		if (ids.length > 0) {
+			field.setAttribute('aria-describedby', ids.join(' '));
+		} else {
+			field.removeAttribute('aria-describedby');
+		}
+	}
+
+	static #parseIdRefs(value) {
+		if (!value) return [];
+		return value.trim().split(/\s+/).filter(Boolean);
+	}
+
+	static #expandCountTemplate(template, matched, total) {
+		return String(template)
+			.replace(/\{matched\}/g, String(matched))
+			.replace(/\{total\}/g, String(total));
+	}
+
+	static #ensureRulePresentation(element) {
+		let iconElement = element.querySelector(
+			':scope > .form-validation-list-rule-icon',
+		);
+		if (!iconElement) {
+			iconElement = document.createElement('span');
+			iconElement.className = 'form-validation-list-rule-icon';
+			iconElement.setAttribute('aria-hidden', 'true');
+			element.prepend(iconElement);
+		}
+
+		let stateElement = element.querySelector(
+			':scope > .form-validation-list-rule-state',
+		);
+		if (!stateElement) {
+			stateElement = document.createElement('span');
+			stateElement.className = 'form-validation-list-rule-state';
+			iconElement.insertAdjacentElement('afterend', stateElement);
+		}
+
+		return { iconElement, stateElement };
+	}
+
+	_updateRulePresentation() {
+		if (this.ruleMatchedIcon) {
+			this.style.setProperty(
+				'--form-validation-list-rule-matched-icon',
+				JSON.stringify(this.ruleMatchedIcon),
+			);
+		} else {
+			this.style.removeProperty(
+				'--form-validation-list-rule-matched-icon',
+			);
+		}
+
+		if (this.ruleUnmatchedIcon) {
+			this.style.setProperty(
+				'--form-validation-list-rule-unmatched-icon',
+				JSON.stringify(this.ruleUnmatchedIcon),
+			);
+		} else {
+			this.style.removeProperty(
+				'--form-validation-list-rule-unmatched-icon',
+			);
+		}
+
+		for (let i = 0; i < this._rules.length; i++) {
+			const { element } = this._rules[i];
+			const { stateElement } =
+				FormValidationListElement.#ensureRulePresentation(element);
+			const isMatched = element.classList.contains(this.ruleMatchedClass);
+			stateElement.textContent = this._hasValue
+				? `${isMatched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
+				: '';
+		}
+	}
+
+	__handleFieldClassChange(oldValue, defaultClass, cacheKey) {
+		const previousClass =
+			oldValue === null ? defaultClass : oldValue || null;
+		this[cacheKey] = null;
+		if (this._field && previousClass) {
+			this._field.classList.remove(previousClass);
+		}
+		if (this._field) {
+			this._validateField();
+		}
+	}
+
+	__handleRuleClassChange(oldValue, defaultClass, cacheKey) {
+		const previousClass =
+			oldValue === null ? defaultClass : oldValue || null;
+		this[cacheKey] = null;
+		if (previousClass) {
+			for (let i = 0; i < this._rules.length; i++) {
+				this._rules[i].element.classList.remove(previousClass);
+			}
+		}
+		if (this._field) {
+			this._validateField();
+		}
+	}
+
+	__rebindValidationHandler(oldValue) {
+		if (!this._field || !this._validationHandler) {
+			return;
+		}
+		this._clearPendingInputThrottle();
+		const previousEvent = this._currentTriggerEvent || oldValue || 'input';
+		const nextEvent = this.triggerEvent;
+		if (previousEvent === nextEvent) {
+			return;
+		}
+		this._field.removeEventListener(previousEvent, this._validationHandler);
+		this._currentTriggerEvent = nextEvent;
+		this._field.addEventListener(nextEvent, this._validationHandler);
+	}
+
+	_clearPendingTimeouts() {
+		if (!this._pendingTimeouts.size) {
+			return;
+		}
+		for (const timeoutId of this._pendingTimeouts) {
+			clearTimeout(timeoutId);
+		}
+		this._pendingTimeouts.clear();
+	}
+
+	_clearPendingInputThrottle() {
+		if (this._pendingInputThrottleTimeout === null) {
+			return;
+		}
+		clearTimeout(this._pendingInputThrottleTimeout);
+		this._pendingInputThrottleTimeout = null;
+	}
+
+	_clearPendingBlurRestore() {
+		if (this._pendingBlurRestoreTimeout === null) {
+			return;
+		}
+		clearTimeout(this._pendingBlurRestoreTimeout);
+		this._pendingBlurRestoreTimeout = null;
+	}
+
+	_scheduleValidation() {
+		if (!this._field) {
+			return;
+		}
+
+		const listenerType = this._currentTriggerEvent || this.triggerEvent;
+		if (listenerType !== 'input') {
+			this._validateField();
+			return;
+		}
+
+		// Cancel pending restore when typing resumes.
+		this._clearPendingBlurRestore();
+
+		// Suspend aria-describedby as soon as the user starts typing
+		this._suspendDescribedBy();
+
+		const throttleDelay = this.inputThrottle;
+		if (throttleDelay <= 0) {
+			this._validateField();
+			return;
+		}
+
+		this._clearPendingInputThrottle();
+		this._pendingInputThrottleTimeout = setTimeout(() => {
+			this._pendingInputThrottleTimeout = null;
+			this._validateField();
+		}, throttleDelay);
+	}
+
+	_validateField() {
+		if (!this._field) return;
+
+		this._clearPendingTimeouts();
+
+		const value = this._field.value;
+		const rulesCount = this._rules.length;
+		let matchedRules = 0;
+		const delay = this.eachDelay;
+
+		// Track whether the field has a value to expose localized rule state text
+		const hasValue = value.length > 0;
+		if (hasValue !== this._hasValue) {
+			this._hasValue = hasValue;
+			this.classList.toggle('has-value', hasValue);
+		}
+
+		// Validate each rule
+		for (let i = 0; i < rulesCount; i++) {
+			const { element, regex } = this._rules[i];
+			const matched = regex.test(value);
+
+			if (matched) {
+				matchedRules++;
+			}
+
+			const applyClasses = () => {
+				this._toggleMatchedClasses(element, matched);
+			};
+
+			// Apply class changes with delay for visual cascade effect
+			if (delay > 0) {
+				const timeoutId = setTimeout(() => {
+					this._pendingTimeouts.delete(timeoutId);
+					applyClasses();
+				}, i * delay);
+				this._pendingTimeouts.add(timeoutId);
+			} else {
+				applyClasses();
+			}
+		}
+
+		// Update field validity
+		const isValid = matchedRules === rulesCount;
+		this._isValid = isValid;
+
+		// Cache class names for performance
+		const validClass = this.fieldValidClass;
+		const invalidClass = this.fieldInvalidClass;
+
+		// Update field classes
+		const fieldClassList = this._field.classList;
+		if (isValid) {
+			fieldClassList.add(validClass);
+			fieldClassList.remove(invalidClass);
+		} else {
+			fieldClassList.add(invalidClass);
+			fieldClassList.remove(validClass);
+		}
+
+		// Update live region with summary announcement
+		if (this._liveRegion) {
+			this._liveRegion.textContent =
+				FormValidationListElement.#expandCountTemplate(
+					this.announcement,
+					matchedRules,
+					rulesCount,
+				);
+		}
+
+		// Integrate with browser validation
+		this._updateFieldValidity(isValid, matchedRules);
+
+		// Fire custom event
+		this.dispatchEvent(
+			new CustomEvent('form-validation-list:validated', {
+				bubbles: true,
+				composed: true,
+				detail: {
+					isValid,
+					matchedRules,
+					totalRules: rulesCount,
+					field: this._field,
+				},
+			}),
+		);
+	}
+
+	_toggleMatchedClasses(element, matched) {
+		const { stateElement } =
+			FormValidationListElement.#ensureRulePresentation(element);
+		const classList = element.classList;
+		if (matched) {
+			classList.add(this.ruleMatchedClass);
+			classList.remove(this.ruleUnmatchedClass);
+		} else {
+			classList.add(this.ruleUnmatchedClass);
+			classList.remove(this.ruleMatchedClass);
+		}
+		stateElement.textContent = this._hasValue
+			? `${matched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
+			: '';
+	}
+
+	_updateFieldValidity(isValid, matchedRules) {
+		if (!this._field || !this._field.setCustomValidity) return;
+
+		if (isValid) {
+			this._field.setCustomValidity('');
+		} else {
+			const template =
+				this.validationMessage ||
+				'Please match all validation requirements ({matched} of {total})';
+			const message = FormValidationListElement.#expandCountTemplate(
+				template,
+				matchedRules,
+				this._rules.length,
+			);
+			this._field.setCustomValidity(message);
+		}
+	}
+
+	_cleanup() {
+		this._clearPendingBlurRestore();
+		this._clearPendingInputThrottle();
+		this._clearPendingTimeouts();
+
+		// Remove event listeners
+		if (this._field && this._validationHandler) {
+			const listenerType =
+				this._currentTriggerEvent || this.triggerEvent || 'input';
+			this._field.removeEventListener(
+				listenerType,
+				this._validationHandler,
+			);
+		}
+		if (this._field && this._blurHandler) {
+			this._field.removeEventListener('blur', this._blurHandler);
+		}
+
+		// Remove this element from the field's aria-describedby on cleanup
+		this._removeOwnDescribedBy();
+
+		// Clear custom validity
+		if (this._field && this._field.setCustomValidity) {
+			this._field.setCustomValidity('');
+		}
+
+		// Remove classes from field
+		if (this._field) {
+			this._field.classList.remove(
+				this.fieldValidClass,
+				this.fieldInvalidClass,
+			);
+		}
+
+		// Remove classes from rules
+		const rulesCount = this._rules.length;
+		const matchedClass = this.ruleMatchedClass;
+		const unmatchedClass = this.ruleUnmatchedClass;
+
+		for (let i = 0; i < rulesCount; i++) {
+			this._rules[i].element.classList.remove(
+				matchedClass,
+				unmatchedClass,
+			);
+		}
+
+		// Remove live region
+		if (this._liveRegion && this._liveRegion.parentNode) {
+			this._liveRegion.remove();
+		}
+
+		// Remove has-value class
+		this.classList.remove('has-value');
+		this.style.removeProperty('--form-validation-list-rule-matched-icon');
+		this.style.removeProperty('--form-validation-list-rule-unmatched-icon');
+
+		this._field = null;
+		this._rules = [];
+		this._validationHandler = null;
+		this._blurHandler = null;
+		this._liveRegion = null;
+		this._pendingBlurRestoreTimeout = null;
+		this._validClasses = null;
+		this._invalidClasses = null;
+		this._matchedClasses = null;
+		this._unmatchedClasses = null;
+		this._currentTriggerEvent = null;
+		this._describedBySuspended = false;
+		this._describedByTargetId = null;
+		this._hasValue = false;
+		this._isValid = false;
+	}
+
+	/**
+	 * Manually trigger validation
+	 * @public
+	 */
+	validate() {
+		this._validateField();
+		return this._isValid;
+	}
+
+	/**
+	 * Get the current validation state
+	 * @public
+	 * @returns {boolean} Whether all rules are currently matched
+	 */
+	get isValid() {
+		return this._isValid;
+	}
 }

--- a/form-validation-list.js
+++ b/form-validation-list.js
@@ -29,40 +29,40 @@
  * @cssprop --rule-unmatched-color - Color for unmatched rules (default: red). Alias: --validation-unmatched-color
  */
 export class FormValidationListElement extends HTMLElement {
-  static #stylesInjected = false;
-  static #styleId = 'form-validation-list-styles';
-  static #describedByRestoreDelay = 200;
-  static #normalizeTriggerEvent(value) {
-    return value === 'blur' ? 'blur' : 'input';
-  }
+	static #stylesInjected = false;
+	static #styleId = 'form-validation-list-styles';
+	static #describedByRestoreDelay = 200;
+	static #normalizeTriggerEvent(value) {
+		return value === 'blur' ? 'blur' : 'input';
+	}
 
-  static get observedAttributes() {
-    return [
-      'for',
-      'trigger-event',
-      'input-throttle',
-      'each-delay',
-      'field-invalid-class',
-      'field-valid-class',
-      'rule-unmatched-class',
-      'rule-matched-class',
-      'rule-matched-icon',
-      'rule-unmatched-icon',
-      'rule-matched-alt',
-      'rule-unmatched-alt',
-      'announcement',
-      'validation-message',
-    ];
-  }
+	static get observedAttributes() {
+		return [
+			'for',
+			'trigger-event',
+			'input-throttle',
+			'each-delay',
+			'field-invalid-class',
+			'field-valid-class',
+			'rule-unmatched-class',
+			'rule-matched-class',
+			'rule-matched-icon',
+			'rule-unmatched-icon',
+			'rule-matched-alt',
+			'rule-unmatched-alt',
+			'announcement',
+			'validation-message',
+		];
+	}
 
-  static #injectStyles() {
-    if (FormValidationListElement.#stylesInjected) {
-      return;
-    }
+	static #injectStyles() {
+		if (FormValidationListElement.#stylesInjected) {
+			return;
+		}
 
-    const style = document.createElement('style');
-    style.id = FormValidationListElement.#styleId;
-    style.textContent = `
+		const style = document.createElement('style');
+		style.id = FormValidationListElement.#styleId;
+		style.textContent = `
 			form-validation-list {
 				display: block;
 			}
@@ -113,913 +113,915 @@ export class FormValidationListElement extends HTMLElement {
 			}
 		`;
 
-    document.head.appendChild(style);
-    FormValidationListElement.#stylesInjected = true;
-  }
-
-  static #generateId() {
-    return `form-validation-list-${Math.random().toString(36).substr(2, 9)}`;
-  }
-
-  constructor() {
-    super();
-    // Use light DOM instead of shadow DOM
-    this._field = null;
-    this._rules = [];
-    this._validationHandler = null;
-    this._isValid = false;
-    this._validClasses = null;
-    this._invalidClasses = null;
-    this._matchedClasses = null;
-    this._unmatchedClasses = null;
-    this._pendingTimeouts = new Set();
-    this._pendingInputThrottleTimeout = null;
-    this._pendingBlurRestoreTimeout = null;
-    this._currentTriggerEvent = null;
-    this._liveRegion = null;
-    this._blurHandler = null;
-    this._describedBySuspended = false;
-    this._hasValue = false;
-  }
-
-  connectedCallback() {
-    this.__upgradeProperty('for');
-    this.__upgradeProperty('fieldId');
-    this.__upgradeProperty('triggerEvent');
-    this.__upgradeProperty('inputThrottle');
-    this.__upgradeProperty('eachDelay');
-    this.__upgradeProperty('fieldInvalidClass');
-    this.__upgradeProperty('fieldValidClass');
-    this.__upgradeProperty('ruleUnmatchedClass');
-    this.__upgradeProperty('ruleMatchedClass');
-    this.__upgradeProperty('ruleMatchedIcon');
-    this.__upgradeProperty('ruleUnmatchedIcon');
-    this.__upgradeProperty('ruleMatchedAlt');
-    this.__upgradeProperty('ruleUnmatchedAlt');
-    this.__upgradeProperty('announcement');
-    this.__upgradeProperty('validationMessage');
-    FormValidationListElement.#injectStyles();
-    this._setupValidation();
-  }
-
-  disconnectedCallback() {
-    this._cleanup();
-  }
-
-  attributeChangedCallback(name, oldValue, newValue) {
-    if (oldValue === newValue) {
-      return;
-    }
-
-    switch (name) {
-      case 'for':
-        if (this.isConnected) {
-          this._cleanup();
-          this._setupValidation();
-        }
-        break;
-      case 'validation-message':
-        if (this._field) {
-          this._validateField();
-        }
-        break;
-      case 'trigger-event':
-        if (newValue !== null) {
-          const normalizedTriggerEvent =
-            FormValidationListElement.#normalizeTriggerEvent(newValue);
-          if (newValue !== normalizedTriggerEvent) {
-            this.setAttribute(
-              'trigger-event',
-              normalizedTriggerEvent,
-            );
-            break;
-          }
-        }
-        this.__rebindValidationHandler(oldValue);
-        break;
-      case 'input-throttle':
-        this._clearPendingInputThrottle();
-        if (this._field) {
-          this._validateField();
-        }
-        break;
-      case 'each-delay':
-        this._clearPendingTimeouts();
-        if (this._field) {
-          this._validateField();
-        }
-        break;
-      case 'field-invalid-class':
-        this.__handleFieldClassChange(
-          oldValue,
-          'validation-invalid',
-          '_invalidClasses',
-        );
-        break;
-      case 'field-valid-class':
-        this.__handleFieldClassChange(
-          oldValue,
-          'validation-valid',
-          '_validClasses',
-        );
-        break;
-      case 'rule-unmatched-class':
-        this.__handleRuleClassChange(
-          oldValue,
-          'validation-unmatched',
-          '_unmatchedClasses',
-        );
-        break;
-      case 'rule-matched-class':
-        this.__handleRuleClassChange(
-          oldValue,
-          'validation-matched',
-          '_matchedClasses',
-        );
-        break;
-      case 'rule-matched-icon':
-      case 'rule-unmatched-icon':
-      case 'rule-matched-alt':
-      case 'rule-unmatched-alt':
-        this._updateRulePresentation();
-        break;
-      case 'announcement':
-        // No immediate action needed; next validation pass will use new template
-        break;
-      default:
-        break;
-    }
-  }
-
-  get ['for']() {
-    return this.fieldId;
-  }
-
-  set ['for'](value) {
-    this.fieldId = value;
-  }
-
-  get fieldId() {
-    return this.getAttribute('for');
-  }
-
-  set fieldId(value) {
-    if (value === null || value === undefined || value === '') {
-      this.removeAttribute('for');
-    } else {
-      this.setAttribute('for', String(value));
-    }
-  }
-
-  // Getters for configuration with cached class names
-  get triggerEvent() {
-    return FormValidationListElement.#normalizeTriggerEvent(
-      this.getAttribute('trigger-event'),
-    );
-  }
-
-  set triggerEvent(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value).trim();
-    if (normalized) {
-      this.setAttribute(
-        'trigger-event',
-        FormValidationListElement.#normalizeTriggerEvent(normalized),
-      );
-    } else {
-      this.removeAttribute('trigger-event');
-    }
-  }
-
-  get inputThrottle() {
-    const attrValue = this.getAttribute('input-throttle');
-    if (attrValue === null || attrValue === undefined || attrValue === '') {
-      return 250;
-    }
-    const parsed = Number(attrValue);
-    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 250;
-  }
-
-  set inputThrottle(value) {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed) && parsed >= 0) {
-      this.setAttribute('input-throttle', String(parsed));
-    } else {
-      this.removeAttribute('input-throttle');
-    }
-  }
-
-  get eachDelay() {
-    const attrValue = this.getAttribute('each-delay');
-    if (attrValue === null || attrValue === undefined || attrValue === '') {
-      return 150;
-    }
-    const parsed = Number(attrValue);
-    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 150;
-  }
-
-  set eachDelay(value) {
-    const parsed = Number(value);
-    if (Number.isFinite(parsed) && parsed >= 0) {
-      this.setAttribute('each-delay', String(parsed));
-    } else {
-      this.removeAttribute('each-delay');
-    }
-  }
-
-  get fieldInvalidClass() {
-    if (this._invalidClasses === null) {
-      const attr = this.getAttribute('field-invalid-class');
-      this._invalidClasses = attr || 'validation-invalid';
-    }
-    return this._invalidClasses;
-  }
-
-  set fieldInvalidClass(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value).trim();
-    if (normalized) {
-      this.setAttribute('field-invalid-class', normalized);
-    } else {
-      this.removeAttribute('field-invalid-class');
-    }
-  }
-
-  get fieldValidClass() {
-    if (this._validClasses === null) {
-      const attr = this.getAttribute('field-valid-class');
-      this._validClasses = attr || 'validation-valid';
-    }
-    return this._validClasses;
-  }
-
-  set fieldValidClass(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value).trim();
-    if (normalized) {
-      this.setAttribute('field-valid-class', normalized);
-    } else {
-      this.removeAttribute('field-valid-class');
-    }
-  }
-
-  get ruleUnmatchedClass() {
-    if (this._unmatchedClasses === null) {
-      const attr = this.getAttribute('rule-unmatched-class');
-      this._unmatchedClasses = attr || 'validation-unmatched';
-    }
-    return this._unmatchedClasses;
-  }
-
-  set ruleUnmatchedClass(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value).trim();
-    if (normalized) {
-      this.setAttribute('rule-unmatched-class', normalized);
-    } else {
-      this.removeAttribute('rule-unmatched-class');
-    }
-  }
-
-  get ruleMatchedClass() {
-    if (this._matchedClasses === null) {
-      const attr = this.getAttribute('rule-matched-class');
-      this._matchedClasses = attr || 'validation-matched';
-    }
-    return this._matchedClasses;
-  }
-
-  set ruleMatchedClass(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value).trim();
-    if (normalized) {
-      this.setAttribute('rule-matched-class', normalized);
-    } else {
-      this.removeAttribute('rule-matched-class');
-    }
-  }
-
-  get validationMessage() {
-    return this.getAttribute('validation-message');
-  }
-
-  set validationMessage(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('validation-message', normalized);
-    } else {
-      this.removeAttribute('validation-message');
-    }
-  }
-
-  get ruleMatchedIcon() {
-    return this.getAttribute('rule-matched-icon');
-  }
-
-  set ruleMatchedIcon(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('rule-matched-icon', normalized);
-    } else {
-      this.removeAttribute('rule-matched-icon');
-    }
-  }
-
-  get ruleUnmatchedIcon() {
-    return this.getAttribute('rule-unmatched-icon');
-  }
-
-  set ruleUnmatchedIcon(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('rule-unmatched-icon', normalized);
-    } else {
-      this.removeAttribute('rule-unmatched-icon');
-    }
-  }
-
-  get ruleMatchedAlt() {
-    const attr = this.getAttribute('rule-matched-alt');
-    return attr !== null ? attr : 'Criteria met';
-  }
-
-  set ruleMatchedAlt(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('rule-matched-alt', normalized);
-    } else {
-      this.removeAttribute('rule-matched-alt');
-    }
-  }
-
-  get ruleUnmatchedAlt() {
-    const attr = this.getAttribute('rule-unmatched-alt');
-    return attr !== null ? attr : 'Criteria not met';
-  }
-
-  set ruleUnmatchedAlt(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('rule-unmatched-alt', normalized);
-    } else {
-      this.removeAttribute('rule-unmatched-alt');
-    }
-  }
-
-  get announcement() {
-    const attr = this.getAttribute('announcement');
-    return attr !== null ? attr : 'Criteria met: {matched} of {total}';
-  }
-
-  set announcement(value) {
-    const normalized =
-      value === null || value === undefined ? '' : String(value);
-    if (normalized) {
-      this.setAttribute('announcement', normalized);
-    } else {
-      this.removeAttribute('announcement');
-    }
-  }
-
-  __upgradeProperty(prop) {
-    if (Object.prototype.hasOwnProperty.call(this, prop)) {
-      const value = this[prop];
-      delete this[prop];
-      this[prop] = value;
-    }
-  }
-
-  _setupValidation() {
-    this._clearPendingTimeouts();
-    const fieldId = this.fieldId;
-    if (!fieldId) return;
-
-    // Find the field
-    this._field = document.getElementById(fieldId);
-    if (!this._field) {
-      console.warn(
-        `form-validation-list: Could not find field with id="${fieldId}"`,
-      );
-      return;
-    }
-
-    this._isValid = false;
-
-    // Find all rules (elements with data-pattern attribute)
-    this._rules = Array.from(this.querySelectorAll('[data-pattern]')).map(
-      (element) => ({
-        element,
-        pattern: element.getAttribute('data-pattern'),
-        regex: new RegExp(element.getAttribute('data-pattern')),
-      }),
-    );
-
-    if (this._rules.length === 0) {
-      console.warn(
-        'form-validation-list: No rules found with data-pattern attribute',
-      );
-      return;
-    }
-
-    // Set up ARIA relationship
-    this._setupAccessibility();
-
-    // Only add aria-atomic to list items; live announcements go through the live region
-    this._rules.forEach(({ element }) => {
-      FormValidationListElement.#ensureRulePresentation(element);
-      element.setAttribute('aria-atomic', 'true');
-    });
-
-    // Create the visually-hidden live region outside this described-by container.
-    if (!this._liveRegion) {
-      this._liveRegion = document.createElement('span');
-      this._liveRegion.setAttribute('aria-live', 'polite');
-      this._liveRegion.setAttribute('aria-atomic', 'true');
-      this._liveRegion.className = 'form-validation-list-live-region';
-      const liveRegionHost = this.parentElement || document.body;
-      liveRegionHost.appendChild(this._liveRegion);
-    }
-
-    // Sync icon glyphs and rule state text for this instance
-    this._updateRulePresentation();
-
-    // Attach blur handler to restore aria-describedby
-    if (!this._blurHandler) {
-      this._blurHandler = () => {
-        this._clearPendingBlurRestore();
-        this._pendingBlurRestoreTimeout = setTimeout(() => {
-          this._pendingBlurRestoreTimeout = null;
-          this._restoreDescribedBy();
-        }, FormValidationListElement.#describedByRestoreDelay);
-        if (this._liveRegion) {
-          this._liveRegion.textContent = '';
-        }
-      };
-      this._field.addEventListener('blur', this._blurHandler);
-    }
-
-    // Create validation handler
-    if (!this._validationHandler) {
-      this._validationHandler = () => {
-        this._scheduleValidation();
-      };
-    }
-
-    // Attach event listener
-    this._currentTriggerEvent = this.triggerEvent;
-    this._field.addEventListener(
-      this._currentTriggerEvent,
-      this._validationHandler,
-    );
-
-    // Run initial validation if field has a value
-    if (this._field.value) {
-      this._validateField();
-    }
-  }
-
-  _setupAccessibility() {
-    if (!this._field) return;
-
-    // Ensure this element has an ID
-    const listId = this.id || FormValidationListElement.#generateId();
-    if (!this.id) {
-      this.id = listId;
-    }
-
-    // Add this list to the field's aria-describedby
-    const existingDescribedBy =
-      this._field.getAttribute('aria-describedby');
-    if (existingDescribedBy) {
-      const describedByIds =
-        FormValidationListElement.#parseIdRefs(existingDescribedBy);
-      if (!describedByIds.includes(listId)) {
-        describedByIds.push(listId);
-        this._field.setAttribute(
-          'aria-describedby',
-          describedByIds.join(' '),
-        );
-      }
-    } else {
-      this._field.setAttribute('aria-describedby', listId);
-    }
-  }
-
-  _suspendDescribedBy() {
-    if (this._describedBySuspended || !this._field || !this.id) return;
-    this._removeOwnDescribedBy();
-    this._describedBySuspended = true;
-  }
-
-  _restoreDescribedBy() {
-    this._clearPendingBlurRestore();
-    if (!this._describedBySuspended || !this._field || !this.id) return;
-    const current = this._field.getAttribute('aria-describedby');
-    if (current) {
-      const ids = FormValidationListElement.#parseIdRefs(current);
-      if (!ids.includes(this.id)) {
-        ids.push(this.id);
-        this._field.setAttribute('aria-describedby', ids.join(' '));
-      }
-    } else {
-      this._field.setAttribute('aria-describedby', this.id);
-    }
-    this._describedBySuspended = false;
-  }
-
-  _removeOwnDescribedBy(field = this._field) {
-    if (!field || !this.id) return;
-    const current = field.getAttribute('aria-describedby');
-    if (!current) return;
-    const ids = FormValidationListElement.#parseIdRefs(current).filter(
-      (id) => id !== this.id,
-    );
-    if (ids.length > 0) {
-      field.setAttribute('aria-describedby', ids.join(' '));
-    } else {
-      field.removeAttribute('aria-describedby');
-    }
-  }
-
-  static #parseIdRefs(value) {
-    if (!value) return [];
-    return value.trim().split(/\s+/).filter(Boolean);
-  }
-
-  static #expandCountTemplate(template, matched, total) {
-    return String(template)
-      .replace(/\{matched\}/g, String(matched))
-      .replace(/\{total\}/g, String(total));
-  }
-
-  static #ensureRulePresentation(element) {
-    let iconElement = element.querySelector(
-      ':scope > .form-validation-list-rule-icon',
-    );
-    if (!iconElement) {
-      iconElement = document.createElement('span');
-      iconElement.className = 'form-validation-list-rule-icon';
-      iconElement.setAttribute('aria-hidden', 'true');
-      element.prepend(iconElement);
-    }
-
-    let stateElement = element.querySelector(
-      ':scope > .form-validation-list-rule-state',
-    );
-    if (!stateElement) {
-      stateElement = document.createElement('span');
-      stateElement.className = 'form-validation-list-rule-state';
-      iconElement.insertAdjacentElement('afterend', stateElement);
-    }
-
-    return { iconElement, stateElement };
-  }
-
-  _updateRulePresentation() {
-    if (this.ruleMatchedIcon) {
-      this.style.setProperty(
-        '--form-validation-list-rule-matched-icon',
-        JSON.stringify(this.ruleMatchedIcon),
-      );
-    } else {
-      this.style.removeProperty(
-        '--form-validation-list-rule-matched-icon',
-      );
-    }
-
-    if (this.ruleUnmatchedIcon) {
-      this.style.setProperty(
-        '--form-validation-list-rule-unmatched-icon',
-        JSON.stringify(this.ruleUnmatchedIcon),
-      );
-    } else {
-      this.style.removeProperty(
-        '--form-validation-list-rule-unmatched-icon',
-      );
-    }
-
-    for (let i = 0; i < this._rules.length; i++) {
-      const { element } = this._rules[i];
-      const { stateElement } =
-        FormValidationListElement.#ensureRulePresentation(element);
-      const isMatched = element.classList.contains(this.ruleMatchedClass);
-      stateElement.textContent = this._hasValue
-        ? `${isMatched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
-        : '';
-    }
-  }
-
-  __handleFieldClassChange(oldValue, defaultClass, cacheKey) {
-    const previousClass =
-      oldValue === null ? defaultClass : oldValue || null;
-    this[cacheKey] = null;
-    if (this._field && previousClass) {
-      this._field.classList.remove(previousClass);
-    }
-    if (this._field) {
-      this._validateField();
-    }
-  }
-
-  __handleRuleClassChange(oldValue, defaultClass, cacheKey) {
-    const previousClass =
-      oldValue === null ? defaultClass : oldValue || null;
-    this[cacheKey] = null;
-    if (previousClass) {
-      for (let i = 0; i < this._rules.length; i++) {
-        this._rules[i].element.classList.remove(previousClass);
-      }
-    }
-    if (this._field) {
-      this._validateField();
-    }
-  }
-
-  __rebindValidationHandler(oldValue) {
-    if (!this._field || !this._validationHandler) {
-      return;
-    }
-    this._clearPendingInputThrottle();
-    const previousEvent = this._currentTriggerEvent || oldValue || 'input';
-    const nextEvent = this.triggerEvent;
-    if (previousEvent === nextEvent) {
-      return;
-    }
-    this._field.removeEventListener(previousEvent, this._validationHandler);
-    this._currentTriggerEvent = nextEvent;
-    this._field.addEventListener(nextEvent, this._validationHandler);
-  }
-
-  _clearPendingTimeouts() {
-    if (!this._pendingTimeouts.size) {
-      return;
-    }
-    for (const timeoutId of this._pendingTimeouts) {
-      clearTimeout(timeoutId);
-    }
-    this._pendingTimeouts.clear();
-  }
-
-  _clearPendingInputThrottle() {
-    if (this._pendingInputThrottleTimeout === null) {
-      return;
-    }
-    clearTimeout(this._pendingInputThrottleTimeout);
-    this._pendingInputThrottleTimeout = null;
-  }
-
-  _clearPendingBlurRestore() {
-    if (this._pendingBlurRestoreTimeout === null) {
-      return;
-    }
-    clearTimeout(this._pendingBlurRestoreTimeout);
-    this._pendingBlurRestoreTimeout = null;
-  }
-
-  _scheduleValidation() {
-    if (!this._field) {
-      return;
-    }
-
-    const listenerType = this._currentTriggerEvent || this.triggerEvent;
-    if (listenerType !== 'input') {
-      this._validateField();
-      return;
-    }
-
-    // Cancel pending restore when typing resumes.
-    this._clearPendingBlurRestore();
-
-    // Suspend aria-describedby as soon as the user starts typing
-    this._suspendDescribedBy();
-
-    const throttleDelay = this.inputThrottle;
-    if (throttleDelay <= 0) {
-      this._validateField();
-      return;
-    }
-
-    this._clearPendingInputThrottle();
-    this._pendingInputThrottleTimeout = setTimeout(() => {
-      this._pendingInputThrottleTimeout = null;
-      this._validateField();
-    }, throttleDelay);
-  }
-
-  _validateField() {
-    if (!this._field) return;
-
-    this._clearPendingTimeouts();
-
-    const value = this._field.value;
-    const rulesCount = this._rules.length;
-    let matchedRules = 0;
-    const delay = this.eachDelay;
-
-    // Track whether the field has a value to expose localized rule state text
-    const hasValue = value.length > 0;
-    if (hasValue !== this._hasValue) {
-      this._hasValue = hasValue;
-      this.classList.toggle('has-value', hasValue);
-    }
-
-    // Validate each rule
-    for (let i = 0; i < rulesCount; i++) {
-      const { element, regex } = this._rules[i];
-      const matched = regex.test(value);
-
-      if (matched) {
-        matchedRules++;
-      }
-
-      const applyClasses = () => {
-        this._toggleMatchedClasses(element, matched);
-      };
-
-      // Apply class changes with delay for visual cascade effect
-      if (delay > 0) {
-        const timeoutId = setTimeout(() => {
-          this._pendingTimeouts.delete(timeoutId);
-          applyClasses();
-        }, i * delay);
-        this._pendingTimeouts.add(timeoutId);
-      } else {
-        applyClasses();
-      }
-    }
-
-    // Update field validity
-    const isValid = matchedRules === rulesCount;
-    this._isValid = isValid;
-
-    // Cache class names for performance
-    const validClass = this.fieldValidClass;
-    const invalidClass = this.fieldInvalidClass;
-
-    // Update field classes
-    const fieldClassList = this._field.classList;
-    if (isValid) {
-      fieldClassList.add(validClass);
-      fieldClassList.remove(invalidClass);
-    } else {
-      fieldClassList.add(invalidClass);
-      fieldClassList.remove(validClass);
-    }
-
-    // Update live region with summary announcement
-    if (this._liveRegion) {
-      this._liveRegion.textContent =
-        FormValidationListElement.#expandCountTemplate(
-          this.announcement,
-          matchedRules,
-          rulesCount,
-        );
-    }
-
-    // Integrate with browser validation
-    this._updateFieldValidity(isValid, matchedRules);
-
-    // Fire custom event
-    this.dispatchEvent(
-      new CustomEvent('form-validation-list:validated', {
-        bubbles: true,
-        composed: true,
-        detail: {
-          isValid,
-          matchedRules,
-          totalRules: rulesCount,
-          field: this._field,
-        },
-      }),
-    );
-  }
-
-  _toggleMatchedClasses(element, matched) {
-    const { stateElement } =
-      FormValidationListElement.#ensureRulePresentation(element);
-    const classList = element.classList;
-    if (matched) {
-      classList.add(this.ruleMatchedClass);
-      classList.remove(this.ruleUnmatchedClass);
-    } else {
-      classList.add(this.ruleUnmatchedClass);
-      classList.remove(this.ruleMatchedClass);
-    }
-    stateElement.textContent = this._hasValue
-      ? `${matched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
-      : '';
-  }
-
-  _updateFieldValidity(isValid, matchedRules) {
-    if (!this._field || !this._field.setCustomValidity) return;
-
-    if (isValid) {
-      this._field.setCustomValidity('');
-    } else {
-      const template =
-        this.validationMessage ||
-        'Please match all validation requirements ({matched} of {total})';
-      const message = FormValidationListElement.#expandCountTemplate(
-        template,
-        matchedRules,
-        this._rules.length,
-      );
-      this._field.setCustomValidity(message);
-    }
-  }
-
-  _cleanup() {
-    this._clearPendingBlurRestore();
-    this._clearPendingInputThrottle();
-    this._clearPendingTimeouts();
-
-    // Remove event listeners
-    if (this._field && this._validationHandler) {
-      const listenerType =
-        this._currentTriggerEvent || this.triggerEvent || 'input';
-      this._field.removeEventListener(
-        listenerType,
-        this._validationHandler,
-      );
-    }
-    if (this._field && this._blurHandler) {
-      this._field.removeEventListener('blur', this._blurHandler);
-    }
-
-    // Remove this element from the field's aria-describedby on cleanup
-    this._removeOwnDescribedBy();
-
-    // Clear custom validity
-    if (this._field && this._field.setCustomValidity) {
-      this._field.setCustomValidity('');
-    }
-
-    // Remove classes from field
-    if (this._field) {
-      this._field.classList.remove(
-        this.fieldValidClass,
-        this.fieldInvalidClass,
-      );
-    }
-
-    // Remove classes from rules
-    const rulesCount = this._rules.length;
-    const matchedClass = this.ruleMatchedClass;
-    const unmatchedClass = this.ruleUnmatchedClass;
-
-    for (let i = 0; i < rulesCount; i++) {
-      this._rules[i].element.classList.remove(
-        matchedClass,
-        unmatchedClass,
-      );
-    }
-
-    // Remove live region
-    if (this._liveRegion && this._liveRegion.parentNode) {
-      this._liveRegion.remove();
-    }
-
-    // Remove has-value class
-    this.classList.remove('has-value');
-    this.style.removeProperty('--form-validation-list-rule-matched-icon');
-    this.style.removeProperty('--form-validation-list-rule-unmatched-icon');
-
-    this._field = null;
-    this._rules = [];
-    this._validationHandler = null;
-    this._blurHandler = null;
-    this._liveRegion = null;
-    this._pendingBlurRestoreTimeout = null;
-    this._validClasses = null;
-    this._invalidClasses = null;
-    this._matchedClasses = null;
-    this._unmatchedClasses = null;
-    this._currentTriggerEvent = null;
-    this._describedBySuspended = false;
-    this._hasValue = false;
-    this._isValid = false;
-  }
-
-  /**
-   * Manually trigger validation
-   * @public
-   */
-  validate() {
-    this._validateField();
-    return this._isValid;
-  }
-
-  /**
-   * Get the current validation state
-   * @public
-   * @returns {boolean} Whether all rules are currently matched
-   */
-  get isValid() {
-    return this._isValid;
-  }
+		document.head.appendChild(style);
+		FormValidationListElement.#stylesInjected = true;
+	}
+
+	static #generateId() {
+		return `form-validation-list-${Math.random().toString(36).substr(2, 9)}`;
+	}
+
+	constructor() {
+		super();
+		// Use light DOM instead of shadow DOM
+		this._field = null;
+		this._rules = [];
+		this._validationHandler = null;
+		this._isValid = false;
+		this._validClasses = null;
+		this._invalidClasses = null;
+		this._matchedClasses = null;
+		this._unmatchedClasses = null;
+		this._pendingTimeouts = new Set();
+		this._pendingInputThrottleTimeout = null;
+		this._pendingBlurRestoreTimeout = null;
+		this._currentTriggerEvent = null;
+		this._liveRegion = null;
+		this._blurHandler = null;
+		this._describedBySuspended = false;
+		this._hasValue = false;
+	}
+
+	connectedCallback() {
+		this.__upgradeProperty('for');
+		this.__upgradeProperty('fieldId');
+		this.__upgradeProperty('triggerEvent');
+		this.__upgradeProperty('inputThrottle');
+		this.__upgradeProperty('eachDelay');
+		this.__upgradeProperty('fieldInvalidClass');
+		this.__upgradeProperty('fieldValidClass');
+		this.__upgradeProperty('ruleUnmatchedClass');
+		this.__upgradeProperty('ruleMatchedClass');
+		this.__upgradeProperty('ruleMatchedIcon');
+		this.__upgradeProperty('ruleUnmatchedIcon');
+		this.__upgradeProperty('ruleMatchedAlt');
+		this.__upgradeProperty('ruleUnmatchedAlt');
+		this.__upgradeProperty('announcement');
+		this.__upgradeProperty('validationMessage');
+		FormValidationListElement.#injectStyles();
+		this._setupValidation();
+	}
+
+	disconnectedCallback() {
+		this._cleanup();
+	}
+
+	attributeChangedCallback(name, oldValue, newValue) {
+		if (oldValue === newValue) {
+			return;
+		}
+
+		switch (name) {
+			case 'for':
+				if (this.isConnected) {
+					this._cleanup();
+					this._setupValidation();
+				}
+				break;
+			case 'validation-message':
+				if (this._field) {
+					this._validateField();
+				}
+				break;
+			case 'trigger-event':
+				if (newValue !== null) {
+					const normalizedTriggerEvent =
+						FormValidationListElement.#normalizeTriggerEvent(
+							newValue,
+						);
+					if (newValue !== normalizedTriggerEvent) {
+						this.setAttribute(
+							'trigger-event',
+							normalizedTriggerEvent,
+						);
+						break;
+					}
+				}
+				this.__rebindValidationHandler(oldValue);
+				break;
+			case 'input-throttle':
+				this._clearPendingInputThrottle();
+				if (this._field) {
+					this._validateField();
+				}
+				break;
+			case 'each-delay':
+				this._clearPendingTimeouts();
+				if (this._field) {
+					this._validateField();
+				}
+				break;
+			case 'field-invalid-class':
+				this.__handleFieldClassChange(
+					oldValue,
+					'validation-invalid',
+					'_invalidClasses',
+				);
+				break;
+			case 'field-valid-class':
+				this.__handleFieldClassChange(
+					oldValue,
+					'validation-valid',
+					'_validClasses',
+				);
+				break;
+			case 'rule-unmatched-class':
+				this.__handleRuleClassChange(
+					oldValue,
+					'validation-unmatched',
+					'_unmatchedClasses',
+				);
+				break;
+			case 'rule-matched-class':
+				this.__handleRuleClassChange(
+					oldValue,
+					'validation-matched',
+					'_matchedClasses',
+				);
+				break;
+			case 'rule-matched-icon':
+			case 'rule-unmatched-icon':
+			case 'rule-matched-alt':
+			case 'rule-unmatched-alt':
+				this._updateRulePresentation();
+				break;
+			case 'announcement':
+				// No immediate action needed; next validation pass will use new template
+				break;
+			default:
+				break;
+		}
+	}
+
+	get ['for']() {
+		return this.fieldId;
+	}
+
+	set ['for'](value) {
+		this.fieldId = value;
+	}
+
+	get fieldId() {
+		return this.getAttribute('for');
+	}
+
+	set fieldId(value) {
+		if (value === null || value === undefined || value === '') {
+			this.removeAttribute('for');
+		} else {
+			this.setAttribute('for', String(value));
+		}
+	}
+
+	// Getters for configuration with cached class names
+	get triggerEvent() {
+		return FormValidationListElement.#normalizeTriggerEvent(
+			this.getAttribute('trigger-event'),
+		);
+	}
+
+	set triggerEvent(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value).trim();
+		if (normalized) {
+			this.setAttribute(
+				'trigger-event',
+				FormValidationListElement.#normalizeTriggerEvent(normalized),
+			);
+		} else {
+			this.removeAttribute('trigger-event');
+		}
+	}
+
+	get inputThrottle() {
+		const attrValue = this.getAttribute('input-throttle');
+		if (attrValue === null || attrValue === undefined || attrValue === '') {
+			return 250;
+		}
+		const parsed = Number(attrValue);
+		return Number.isFinite(parsed) && parsed >= 0 ? parsed : 250;
+	}
+
+	set inputThrottle(value) {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed) && parsed >= 0) {
+			this.setAttribute('input-throttle', String(parsed));
+		} else {
+			this.removeAttribute('input-throttle');
+		}
+	}
+
+	get eachDelay() {
+		const attrValue = this.getAttribute('each-delay');
+		if (attrValue === null || attrValue === undefined || attrValue === '') {
+			return 150;
+		}
+		const parsed = Number(attrValue);
+		return Number.isFinite(parsed) && parsed >= 0 ? parsed : 150;
+	}
+
+	set eachDelay(value) {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed) && parsed >= 0) {
+			this.setAttribute('each-delay', String(parsed));
+		} else {
+			this.removeAttribute('each-delay');
+		}
+	}
+
+	get fieldInvalidClass() {
+		if (this._invalidClasses === null) {
+			const attr = this.getAttribute('field-invalid-class');
+			this._invalidClasses = attr || 'validation-invalid';
+		}
+		return this._invalidClasses;
+	}
+
+	set fieldInvalidClass(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value).trim();
+		if (normalized) {
+			this.setAttribute('field-invalid-class', normalized);
+		} else {
+			this.removeAttribute('field-invalid-class');
+		}
+	}
+
+	get fieldValidClass() {
+		if (this._validClasses === null) {
+			const attr = this.getAttribute('field-valid-class');
+			this._validClasses = attr || 'validation-valid';
+		}
+		return this._validClasses;
+	}
+
+	set fieldValidClass(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value).trim();
+		if (normalized) {
+			this.setAttribute('field-valid-class', normalized);
+		} else {
+			this.removeAttribute('field-valid-class');
+		}
+	}
+
+	get ruleUnmatchedClass() {
+		if (this._unmatchedClasses === null) {
+			const attr = this.getAttribute('rule-unmatched-class');
+			this._unmatchedClasses = attr || 'validation-unmatched';
+		}
+		return this._unmatchedClasses;
+	}
+
+	set ruleUnmatchedClass(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value).trim();
+		if (normalized) {
+			this.setAttribute('rule-unmatched-class', normalized);
+		} else {
+			this.removeAttribute('rule-unmatched-class');
+		}
+	}
+
+	get ruleMatchedClass() {
+		if (this._matchedClasses === null) {
+			const attr = this.getAttribute('rule-matched-class');
+			this._matchedClasses = attr || 'validation-matched';
+		}
+		return this._matchedClasses;
+	}
+
+	set ruleMatchedClass(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value).trim();
+		if (normalized) {
+			this.setAttribute('rule-matched-class', normalized);
+		} else {
+			this.removeAttribute('rule-matched-class');
+		}
+	}
+
+	get validationMessage() {
+		return this.getAttribute('validation-message');
+	}
+
+	set validationMessage(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('validation-message', normalized);
+		} else {
+			this.removeAttribute('validation-message');
+		}
+	}
+
+	get ruleMatchedIcon() {
+		return this.getAttribute('rule-matched-icon');
+	}
+
+	set ruleMatchedIcon(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-matched-icon', normalized);
+		} else {
+			this.removeAttribute('rule-matched-icon');
+		}
+	}
+
+	get ruleUnmatchedIcon() {
+		return this.getAttribute('rule-unmatched-icon');
+	}
+
+	set ruleUnmatchedIcon(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-unmatched-icon', normalized);
+		} else {
+			this.removeAttribute('rule-unmatched-icon');
+		}
+	}
+
+	get ruleMatchedAlt() {
+		const attr = this.getAttribute('rule-matched-alt');
+		return attr !== null ? attr : 'Criteria met';
+	}
+
+	set ruleMatchedAlt(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-matched-alt', normalized);
+		} else {
+			this.removeAttribute('rule-matched-alt');
+		}
+	}
+
+	get ruleUnmatchedAlt() {
+		const attr = this.getAttribute('rule-unmatched-alt');
+		return attr !== null ? attr : 'Criteria not met';
+	}
+
+	set ruleUnmatchedAlt(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-unmatched-alt', normalized);
+		} else {
+			this.removeAttribute('rule-unmatched-alt');
+		}
+	}
+
+	get announcement() {
+		const attr = this.getAttribute('announcement');
+		return attr !== null ? attr : 'Criteria met: {matched} of {total}';
+	}
+
+	set announcement(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('announcement', normalized);
+		} else {
+			this.removeAttribute('announcement');
+		}
+	}
+
+	__upgradeProperty(prop) {
+		if (Object.prototype.hasOwnProperty.call(this, prop)) {
+			const value = this[prop];
+			delete this[prop];
+			this[prop] = value;
+		}
+	}
+
+	_setupValidation() {
+		this._clearPendingTimeouts();
+		const fieldId = this.fieldId;
+		if (!fieldId) return;
+
+		// Find the field
+		this._field = document.getElementById(fieldId);
+		if (!this._field) {
+			console.warn(
+				`form-validation-list: Could not find field with id="${fieldId}"`,
+			);
+			return;
+		}
+
+		this._isValid = false;
+
+		// Find all rules (elements with data-pattern attribute)
+		this._rules = Array.from(this.querySelectorAll('[data-pattern]')).map(
+			(element) => ({
+				element,
+				pattern: element.getAttribute('data-pattern'),
+				regex: new RegExp(element.getAttribute('data-pattern')),
+			}),
+		);
+
+		if (this._rules.length === 0) {
+			console.warn(
+				'form-validation-list: No rules found with data-pattern attribute',
+			);
+			return;
+		}
+
+		// Set up ARIA relationship
+		this._setupAccessibility();
+
+		// Only add aria-atomic to list items; live announcements go through the live region
+		this._rules.forEach(({ element }) => {
+			FormValidationListElement.#ensureRulePresentation(element);
+			element.setAttribute('aria-atomic', 'true');
+		});
+
+		// Create the visually-hidden live region outside this described-by container.
+		if (!this._liveRegion) {
+			this._liveRegion = document.createElement('span');
+			this._liveRegion.setAttribute('aria-live', 'polite');
+			this._liveRegion.setAttribute('aria-atomic', 'true');
+			this._liveRegion.className = 'form-validation-list-live-region';
+			const liveRegionHost = this.parentElement || document.body;
+			liveRegionHost.appendChild(this._liveRegion);
+		}
+
+		// Sync icon glyphs and rule state text for this instance
+		this._updateRulePresentation();
+
+		// Attach blur handler to restore aria-describedby
+		if (!this._blurHandler) {
+			this._blurHandler = () => {
+				this._clearPendingBlurRestore();
+				this._pendingBlurRestoreTimeout = setTimeout(() => {
+					this._pendingBlurRestoreTimeout = null;
+					this._restoreDescribedBy();
+				}, FormValidationListElement.#describedByRestoreDelay);
+				if (this._liveRegion) {
+					this._liveRegion.textContent = '';
+				}
+			};
+			this._field.addEventListener('blur', this._blurHandler);
+		}
+
+		// Create validation handler
+		if (!this._validationHandler) {
+			this._validationHandler = () => {
+				this._scheduleValidation();
+			};
+		}
+
+		// Attach event listener
+		this._currentTriggerEvent = this.triggerEvent;
+		this._field.addEventListener(
+			this._currentTriggerEvent,
+			this._validationHandler,
+		);
+
+		// Run initial validation if field has a value
+		if (this._field.value) {
+			this._validateField();
+		}
+	}
+
+	_setupAccessibility() {
+		if (!this._field) return;
+
+		// Ensure this element has an ID
+		const listId = this.id || FormValidationListElement.#generateId();
+		if (!this.id) {
+			this.id = listId;
+		}
+
+		// Add this list to the field's aria-describedby
+		const existingDescribedBy =
+			this._field.getAttribute('aria-describedby');
+		if (existingDescribedBy) {
+			const describedByIds =
+				FormValidationListElement.#parseIdRefs(existingDescribedBy);
+			if (!describedByIds.includes(listId)) {
+				describedByIds.push(listId);
+				this._field.setAttribute(
+					'aria-describedby',
+					describedByIds.join(' '),
+				);
+			}
+		} else {
+			this._field.setAttribute('aria-describedby', listId);
+		}
+	}
+
+	_suspendDescribedBy() {
+		if (this._describedBySuspended || !this._field || !this.id) return;
+		this._removeOwnDescribedBy();
+		this._describedBySuspended = true;
+	}
+
+	_restoreDescribedBy() {
+		this._clearPendingBlurRestore();
+		if (!this._describedBySuspended || !this._field || !this.id) return;
+		const current = this._field.getAttribute('aria-describedby');
+		if (current) {
+			const ids = FormValidationListElement.#parseIdRefs(current);
+			if (!ids.includes(this.id)) {
+				ids.push(this.id);
+				this._field.setAttribute('aria-describedby', ids.join(' '));
+			}
+		} else {
+			this._field.setAttribute('aria-describedby', this.id);
+		}
+		this._describedBySuspended = false;
+	}
+
+	_removeOwnDescribedBy(field = this._field) {
+		if (!field || !this.id) return;
+		const current = field.getAttribute('aria-describedby');
+		if (!current) return;
+		const ids = FormValidationListElement.#parseIdRefs(current).filter(
+			(id) => id !== this.id,
+		);
+		if (ids.length > 0) {
+			field.setAttribute('aria-describedby', ids.join(' '));
+		} else {
+			field.removeAttribute('aria-describedby');
+		}
+	}
+
+	static #parseIdRefs(value) {
+		if (!value) return [];
+		return value.trim().split(/\s+/).filter(Boolean);
+	}
+
+	static #expandCountTemplate(template, matched, total) {
+		return String(template)
+			.replace(/\{matched\}/g, String(matched))
+			.replace(/\{total\}/g, String(total));
+	}
+
+	static #ensureRulePresentation(element) {
+		let iconElement = element.querySelector(
+			':scope > .form-validation-list-rule-icon',
+		);
+		if (!iconElement) {
+			iconElement = document.createElement('span');
+			iconElement.className = 'form-validation-list-rule-icon';
+			iconElement.setAttribute('aria-hidden', 'true');
+			element.prepend(iconElement);
+		}
+
+		let stateElement = element.querySelector(
+			':scope > .form-validation-list-rule-state',
+		);
+		if (!stateElement) {
+			stateElement = document.createElement('span');
+			stateElement.className = 'form-validation-list-rule-state';
+			iconElement.insertAdjacentElement('afterend', stateElement);
+		}
+
+		return { iconElement, stateElement };
+	}
+
+	_updateRulePresentation() {
+		if (this.ruleMatchedIcon) {
+			this.style.setProperty(
+				'--form-validation-list-rule-matched-icon',
+				JSON.stringify(this.ruleMatchedIcon),
+			);
+		} else {
+			this.style.removeProperty(
+				'--form-validation-list-rule-matched-icon',
+			);
+		}
+
+		if (this.ruleUnmatchedIcon) {
+			this.style.setProperty(
+				'--form-validation-list-rule-unmatched-icon',
+				JSON.stringify(this.ruleUnmatchedIcon),
+			);
+		} else {
+			this.style.removeProperty(
+				'--form-validation-list-rule-unmatched-icon',
+			);
+		}
+
+		for (let i = 0; i < this._rules.length; i++) {
+			const { element } = this._rules[i];
+			const { stateElement } =
+				FormValidationListElement.#ensureRulePresentation(element);
+			const isMatched = element.classList.contains(this.ruleMatchedClass);
+			stateElement.textContent = this._hasValue
+				? `${isMatched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
+				: '';
+		}
+	}
+
+	__handleFieldClassChange(oldValue, defaultClass, cacheKey) {
+		const previousClass =
+			oldValue === null ? defaultClass : oldValue || null;
+		this[cacheKey] = null;
+		if (this._field && previousClass) {
+			this._field.classList.remove(previousClass);
+		}
+		if (this._field) {
+			this._validateField();
+		}
+	}
+
+	__handleRuleClassChange(oldValue, defaultClass, cacheKey) {
+		const previousClass =
+			oldValue === null ? defaultClass : oldValue || null;
+		this[cacheKey] = null;
+		if (previousClass) {
+			for (let i = 0; i < this._rules.length; i++) {
+				this._rules[i].element.classList.remove(previousClass);
+			}
+		}
+		if (this._field) {
+			this._validateField();
+		}
+	}
+
+	__rebindValidationHandler(oldValue) {
+		if (!this._field || !this._validationHandler) {
+			return;
+		}
+		this._clearPendingInputThrottle();
+		const previousEvent = this._currentTriggerEvent || oldValue || 'input';
+		const nextEvent = this.triggerEvent;
+		if (previousEvent === nextEvent) {
+			return;
+		}
+		this._field.removeEventListener(previousEvent, this._validationHandler);
+		this._currentTriggerEvent = nextEvent;
+		this._field.addEventListener(nextEvent, this._validationHandler);
+	}
+
+	_clearPendingTimeouts() {
+		if (!this._pendingTimeouts.size) {
+			return;
+		}
+		for (const timeoutId of this._pendingTimeouts) {
+			clearTimeout(timeoutId);
+		}
+		this._pendingTimeouts.clear();
+	}
+
+	_clearPendingInputThrottle() {
+		if (this._pendingInputThrottleTimeout === null) {
+			return;
+		}
+		clearTimeout(this._pendingInputThrottleTimeout);
+		this._pendingInputThrottleTimeout = null;
+	}
+
+	_clearPendingBlurRestore() {
+		if (this._pendingBlurRestoreTimeout === null) {
+			return;
+		}
+		clearTimeout(this._pendingBlurRestoreTimeout);
+		this._pendingBlurRestoreTimeout = null;
+	}
+
+	_scheduleValidation() {
+		if (!this._field) {
+			return;
+		}
+
+		const listenerType = this._currentTriggerEvent || this.triggerEvent;
+		if (listenerType !== 'input') {
+			this._validateField();
+			return;
+		}
+
+		// Cancel pending restore when typing resumes.
+		this._clearPendingBlurRestore();
+
+		// Suspend aria-describedby as soon as the user starts typing
+		this._suspendDescribedBy();
+
+		const throttleDelay = this.inputThrottle;
+		if (throttleDelay <= 0) {
+			this._validateField();
+			return;
+		}
+
+		this._clearPendingInputThrottle();
+		this._pendingInputThrottleTimeout = setTimeout(() => {
+			this._pendingInputThrottleTimeout = null;
+			this._validateField();
+		}, throttleDelay);
+	}
+
+	_validateField() {
+		if (!this._field) return;
+
+		this._clearPendingTimeouts();
+
+		const value = this._field.value;
+		const rulesCount = this._rules.length;
+		let matchedRules = 0;
+		const delay = this.eachDelay;
+
+		// Track whether the field has a value to expose localized rule state text
+		const hasValue = value.length > 0;
+		if (hasValue !== this._hasValue) {
+			this._hasValue = hasValue;
+			this.classList.toggle('has-value', hasValue);
+		}
+
+		// Validate each rule
+		for (let i = 0; i < rulesCount; i++) {
+			const { element, regex } = this._rules[i];
+			const matched = regex.test(value);
+
+			if (matched) {
+				matchedRules++;
+			}
+
+			const applyClasses = () => {
+				this._toggleMatchedClasses(element, matched);
+			};
+
+			// Apply class changes with delay for visual cascade effect
+			if (delay > 0) {
+				const timeoutId = setTimeout(() => {
+					this._pendingTimeouts.delete(timeoutId);
+					applyClasses();
+				}, i * delay);
+				this._pendingTimeouts.add(timeoutId);
+			} else {
+				applyClasses();
+			}
+		}
+
+		// Update field validity
+		const isValid = matchedRules === rulesCount;
+		this._isValid = isValid;
+
+		// Cache class names for performance
+		const validClass = this.fieldValidClass;
+		const invalidClass = this.fieldInvalidClass;
+
+		// Update field classes
+		const fieldClassList = this._field.classList;
+		if (isValid) {
+			fieldClassList.add(validClass);
+			fieldClassList.remove(invalidClass);
+		} else {
+			fieldClassList.add(invalidClass);
+			fieldClassList.remove(validClass);
+		}
+
+		// Update live region with summary announcement
+		if (this._liveRegion) {
+			this._liveRegion.textContent =
+				FormValidationListElement.#expandCountTemplate(
+					this.announcement,
+					matchedRules,
+					rulesCount,
+				);
+		}
+
+		// Integrate with browser validation
+		this._updateFieldValidity(isValid, matchedRules);
+
+		// Fire custom event
+		this.dispatchEvent(
+			new CustomEvent('form-validation-list:validated', {
+				bubbles: true,
+				composed: true,
+				detail: {
+					isValid,
+					matchedRules,
+					totalRules: rulesCount,
+					field: this._field,
+				},
+			}),
+		);
+	}
+
+	_toggleMatchedClasses(element, matched) {
+		const { stateElement } =
+			FormValidationListElement.#ensureRulePresentation(element);
+		const classList = element.classList;
+		if (matched) {
+			classList.add(this.ruleMatchedClass);
+			classList.remove(this.ruleUnmatchedClass);
+		} else {
+			classList.add(this.ruleUnmatchedClass);
+			classList.remove(this.ruleMatchedClass);
+		}
+		stateElement.textContent = this._hasValue
+			? `${matched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
+			: '';
+	}
+
+	_updateFieldValidity(isValid, matchedRules) {
+		if (!this._field || !this._field.setCustomValidity) return;
+
+		if (isValid) {
+			this._field.setCustomValidity('');
+		} else {
+			const template =
+				this.validationMessage ||
+				'Please match all validation requirements ({matched} of {total})';
+			const message = FormValidationListElement.#expandCountTemplate(
+				template,
+				matchedRules,
+				this._rules.length,
+			);
+			this._field.setCustomValidity(message);
+		}
+	}
+
+	_cleanup() {
+		this._clearPendingBlurRestore();
+		this._clearPendingInputThrottle();
+		this._clearPendingTimeouts();
+
+		// Remove event listeners
+		if (this._field && this._validationHandler) {
+			const listenerType =
+				this._currentTriggerEvent || this.triggerEvent || 'input';
+			this._field.removeEventListener(
+				listenerType,
+				this._validationHandler,
+			);
+		}
+		if (this._field && this._blurHandler) {
+			this._field.removeEventListener('blur', this._blurHandler);
+		}
+
+		// Remove this element from the field's aria-describedby on cleanup
+		this._removeOwnDescribedBy();
+
+		// Clear custom validity
+		if (this._field && this._field.setCustomValidity) {
+			this._field.setCustomValidity('');
+		}
+
+		// Remove classes from field
+		if (this._field) {
+			this._field.classList.remove(
+				this.fieldValidClass,
+				this.fieldInvalidClass,
+			);
+		}
+
+		// Remove classes from rules
+		const rulesCount = this._rules.length;
+		const matchedClass = this.ruleMatchedClass;
+		const unmatchedClass = this.ruleUnmatchedClass;
+
+		for (let i = 0; i < rulesCount; i++) {
+			this._rules[i].element.classList.remove(
+				matchedClass,
+				unmatchedClass,
+			);
+		}
+
+		// Remove live region
+		if (this._liveRegion && this._liveRegion.parentNode) {
+			this._liveRegion.remove();
+		}
+
+		// Remove has-value class
+		this.classList.remove('has-value');
+		this.style.removeProperty('--form-validation-list-rule-matched-icon');
+		this.style.removeProperty('--form-validation-list-rule-unmatched-icon');
+
+		this._field = null;
+		this._rules = [];
+		this._validationHandler = null;
+		this._blurHandler = null;
+		this._liveRegion = null;
+		this._pendingBlurRestoreTimeout = null;
+		this._validClasses = null;
+		this._invalidClasses = null;
+		this._matchedClasses = null;
+		this._unmatchedClasses = null;
+		this._currentTriggerEvent = null;
+		this._describedBySuspended = false;
+		this._hasValue = false;
+		this._isValid = false;
+	}
+
+	/**
+	 * Manually trigger validation
+	 * @public
+	 */
+	validate() {
+		this._validateField();
+		return this._isValid;
+	}
+
+	/**
+	 * Get the current validation state
+	 * @public
+	 * @returns {boolean} Whether all rules are currently matched
+	 */
+	get isValid() {
+		return this._isValid;
+	}
 }

--- a/form-validation-list.js
+++ b/form-validation-list.js
@@ -29,40 +29,40 @@
  * @cssprop --rule-unmatched-color - Color for unmatched rules (default: red). Alias: --validation-unmatched-color
  */
 export class FormValidationListElement extends HTMLElement {
-	static #stylesInjected = false;
-	static #styleId = 'form-validation-list-styles';
-	static #describedByRestoreDelay = 200;
-	static #normalizeTriggerEvent(value) {
-		return value === 'blur' ? 'blur' : 'input';
-	}
+  static #stylesInjected = false;
+  static #styleId = 'form-validation-list-styles';
+  static #describedByRestoreDelay = 200;
+  static #normalizeTriggerEvent(value) {
+    return value === 'blur' ? 'blur' : 'input';
+  }
 
-	static get observedAttributes() {
-		return [
-			'for',
-			'trigger-event',
-			'input-throttle',
-			'each-delay',
-			'field-invalid-class',
-			'field-valid-class',
-			'rule-unmatched-class',
-			'rule-matched-class',
-			'rule-matched-icon',
-			'rule-unmatched-icon',
-			'rule-matched-alt',
-			'rule-unmatched-alt',
-			'announcement',
-			'validation-message',
-		];
-	}
+  static get observedAttributes() {
+    return [
+      'for',
+      'trigger-event',
+      'input-throttle',
+      'each-delay',
+      'field-invalid-class',
+      'field-valid-class',
+      'rule-unmatched-class',
+      'rule-matched-class',
+      'rule-matched-icon',
+      'rule-unmatched-icon',
+      'rule-matched-alt',
+      'rule-unmatched-alt',
+      'announcement',
+      'validation-message',
+    ];
+  }
 
-	static #injectStyles() {
-		if (FormValidationListElement.#stylesInjected) {
-			return;
-		}
+  static #injectStyles() {
+    if (FormValidationListElement.#stylesInjected) {
+      return;
+    }
 
-		const style = document.createElement('style');
-		style.id = FormValidationListElement.#styleId;
-		style.textContent = `
+    const style = document.createElement('style');
+    style.id = FormValidationListElement.#styleId;
+    style.textContent = `
 			form-validation-list {
 				display: block;
 			}
@@ -113,915 +113,930 @@ export class FormValidationListElement extends HTMLElement {
 			}
 		`;
 
-		document.head.appendChild(style);
-		FormValidationListElement.#stylesInjected = true;
-	}
-
-	static #generateId() {
-		return `form-validation-list-${Math.random().toString(36).substr(2, 9)}`;
-	}
-
-	constructor() {
-		super();
-		// Use light DOM instead of shadow DOM
-		this._field = null;
-		this._rules = [];
-		this._validationHandler = null;
-		this._isValid = false;
-		this._validClasses = null;
-		this._invalidClasses = null;
-		this._matchedClasses = null;
-		this._unmatchedClasses = null;
-		this._pendingTimeouts = new Set();
-		this._pendingInputThrottleTimeout = null;
-		this._pendingBlurRestoreTimeout = null;
-		this._currentTriggerEvent = null;
-		this._liveRegion = null;
-		this._blurHandler = null;
-		this._describedBySuspended = false;
-		this._hasValue = false;
-	}
-
-	connectedCallback() {
-		this.__upgradeProperty('for');
-		this.__upgradeProperty('fieldId');
-		this.__upgradeProperty('triggerEvent');
-		this.__upgradeProperty('inputThrottle');
-		this.__upgradeProperty('eachDelay');
-		this.__upgradeProperty('fieldInvalidClass');
-		this.__upgradeProperty('fieldValidClass');
-		this.__upgradeProperty('ruleUnmatchedClass');
-		this.__upgradeProperty('ruleMatchedClass');
-		this.__upgradeProperty('ruleMatchedIcon');
-		this.__upgradeProperty('ruleUnmatchedIcon');
-		this.__upgradeProperty('ruleMatchedAlt');
-		this.__upgradeProperty('ruleUnmatchedAlt');
-		this.__upgradeProperty('announcement');
-		this.__upgradeProperty('validationMessage');
-		FormValidationListElement.#injectStyles();
-		this._setupValidation();
-	}
-
-	disconnectedCallback() {
-		this._cleanup();
-	}
-
-	attributeChangedCallback(name, oldValue, newValue) {
-		if (oldValue === newValue) {
-			return;
-		}
-
-		switch (name) {
-			case 'for':
-				if (this.isConnected) {
-					this._cleanup();
-					this._setupValidation();
-				}
-				break;
-			case 'validation-message':
-				if (this._field) {
-					this._validateField();
-				}
-				break;
-			case 'trigger-event':
-				if (newValue !== null) {
-					const normalizedTriggerEvent =
-						FormValidationListElement.#normalizeTriggerEvent(
-							newValue,
-						);
-					if (newValue !== normalizedTriggerEvent) {
-						this.setAttribute(
-							'trigger-event',
-							normalizedTriggerEvent,
-						);
-						break;
-					}
-				}
-				this.__rebindValidationHandler(oldValue);
-				break;
-			case 'input-throttle':
-				this._clearPendingInputThrottle();
-				if (this._field) {
-					this._validateField();
-				}
-				break;
-			case 'each-delay':
-				this._clearPendingTimeouts();
-				if (this._field) {
-					this._validateField();
-				}
-				break;
-			case 'field-invalid-class':
-				this.__handleFieldClassChange(
-					oldValue,
-					'validation-invalid',
-					'_invalidClasses',
-				);
-				break;
-			case 'field-valid-class':
-				this.__handleFieldClassChange(
-					oldValue,
-					'validation-valid',
-					'_validClasses',
-				);
-				break;
-			case 'rule-unmatched-class':
-				this.__handleRuleClassChange(
-					oldValue,
-					'validation-unmatched',
-					'_unmatchedClasses',
-				);
-				break;
-			case 'rule-matched-class':
-				this.__handleRuleClassChange(
-					oldValue,
-					'validation-matched',
-					'_matchedClasses',
-				);
-				break;
-			case 'rule-matched-icon':
-			case 'rule-unmatched-icon':
-			case 'rule-matched-alt':
-			case 'rule-unmatched-alt':
-				this._updateRulePresentation();
-				break;
-			case 'announcement':
-				// No immediate action needed; next validation pass will use new template
-				break;
-			default:
-				break;
-		}
-	}
-
-	get ['for']() {
-		return this.fieldId;
-	}
-
-	set ['for'](value) {
-		this.fieldId = value;
-	}
-
-	get fieldId() {
-		return this.getAttribute('for');
-	}
-
-	set fieldId(value) {
-		if (value === null || value === undefined || value === '') {
-			this.removeAttribute('for');
-		} else {
-			this.setAttribute('for', String(value));
-		}
-	}
-
-	// Getters for configuration with cached class names
-	get triggerEvent() {
-		return FormValidationListElement.#normalizeTriggerEvent(
-			this.getAttribute('trigger-event'),
-		);
-	}
-
-	set triggerEvent(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value).trim();
-		if (normalized) {
-			this.setAttribute(
-				'trigger-event',
-				FormValidationListElement.#normalizeTriggerEvent(normalized),
-			);
-		} else {
-			this.removeAttribute('trigger-event');
-		}
-	}
-
-	get inputThrottle() {
-		const attrValue = this.getAttribute('input-throttle');
-		if (attrValue === null || attrValue === undefined || attrValue === '') {
-			return 250;
-		}
-		const parsed = Number(attrValue);
-		return Number.isFinite(parsed) && parsed >= 0 ? parsed : 250;
-	}
-
-	set inputThrottle(value) {
-		const parsed = Number(value);
-		if (Number.isFinite(parsed) && parsed >= 0) {
-			this.setAttribute('input-throttle', String(parsed));
-		} else {
-			this.removeAttribute('input-throttle');
-		}
-	}
-
-	get eachDelay() {
-		const attrValue = this.getAttribute('each-delay');
-		if (attrValue === null || attrValue === undefined || attrValue === '') {
-			return 150;
-		}
-		const parsed = Number(attrValue);
-		return Number.isFinite(parsed) && parsed >= 0 ? parsed : 150;
-	}
-
-	set eachDelay(value) {
-		const parsed = Number(value);
-		if (Number.isFinite(parsed) && parsed >= 0) {
-			this.setAttribute('each-delay', String(parsed));
-		} else {
-			this.removeAttribute('each-delay');
-		}
-	}
-
-	get fieldInvalidClass() {
-		if (this._invalidClasses === null) {
-			const attr = this.getAttribute('field-invalid-class');
-			this._invalidClasses = attr || 'validation-invalid';
-		}
-		return this._invalidClasses;
-	}
-
-	set fieldInvalidClass(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value).trim();
-		if (normalized) {
-			this.setAttribute('field-invalid-class', normalized);
-		} else {
-			this.removeAttribute('field-invalid-class');
-		}
-	}
-
-	get fieldValidClass() {
-		if (this._validClasses === null) {
-			const attr = this.getAttribute('field-valid-class');
-			this._validClasses = attr || 'validation-valid';
-		}
-		return this._validClasses;
-	}
-
-	set fieldValidClass(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value).trim();
-		if (normalized) {
-			this.setAttribute('field-valid-class', normalized);
-		} else {
-			this.removeAttribute('field-valid-class');
-		}
-	}
-
-	get ruleUnmatchedClass() {
-		if (this._unmatchedClasses === null) {
-			const attr = this.getAttribute('rule-unmatched-class');
-			this._unmatchedClasses = attr || 'validation-unmatched';
-		}
-		return this._unmatchedClasses;
-	}
-
-	set ruleUnmatchedClass(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value).trim();
-		if (normalized) {
-			this.setAttribute('rule-unmatched-class', normalized);
-		} else {
-			this.removeAttribute('rule-unmatched-class');
-		}
-	}
-
-	get ruleMatchedClass() {
-		if (this._matchedClasses === null) {
-			const attr = this.getAttribute('rule-matched-class');
-			this._matchedClasses = attr || 'validation-matched';
-		}
-		return this._matchedClasses;
-	}
-
-	set ruleMatchedClass(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value).trim();
-		if (normalized) {
-			this.setAttribute('rule-matched-class', normalized);
-		} else {
-			this.removeAttribute('rule-matched-class');
-		}
-	}
-
-	get validationMessage() {
-		return this.getAttribute('validation-message');
-	}
-
-	set validationMessage(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('validation-message', normalized);
-		} else {
-			this.removeAttribute('validation-message');
-		}
-	}
-
-	get ruleMatchedIcon() {
-		return this.getAttribute('rule-matched-icon');
-	}
-
-	set ruleMatchedIcon(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('rule-matched-icon', normalized);
-		} else {
-			this.removeAttribute('rule-matched-icon');
-		}
-	}
-
-	get ruleUnmatchedIcon() {
-		return this.getAttribute('rule-unmatched-icon');
-	}
-
-	set ruleUnmatchedIcon(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('rule-unmatched-icon', normalized);
-		} else {
-			this.removeAttribute('rule-unmatched-icon');
-		}
-	}
-
-	get ruleMatchedAlt() {
-		const attr = this.getAttribute('rule-matched-alt');
-		return attr !== null ? attr : 'Criteria met';
-	}
-
-	set ruleMatchedAlt(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('rule-matched-alt', normalized);
-		} else {
-			this.removeAttribute('rule-matched-alt');
-		}
-	}
-
-	get ruleUnmatchedAlt() {
-		const attr = this.getAttribute('rule-unmatched-alt');
-		return attr !== null ? attr : 'Criteria not met';
-	}
-
-	set ruleUnmatchedAlt(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('rule-unmatched-alt', normalized);
-		} else {
-			this.removeAttribute('rule-unmatched-alt');
-		}
-	}
-
-	get announcement() {
-		const attr = this.getAttribute('announcement');
-		return attr !== null ? attr : 'Criteria met: {matched} of {total}';
-	}
-
-	set announcement(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('announcement', normalized);
-		} else {
-			this.removeAttribute('announcement');
-		}
-	}
-
-	__upgradeProperty(prop) {
-		if (Object.prototype.hasOwnProperty.call(this, prop)) {
-			const value = this[prop];
-			delete this[prop];
-			this[prop] = value;
-		}
-	}
-
-	_setupValidation() {
-		this._clearPendingTimeouts();
-		const fieldId = this.fieldId;
-		if (!fieldId) return;
-
-		// Find the field
-		this._field = document.getElementById(fieldId);
-		if (!this._field) {
-			console.warn(
-				`form-validation-list: Could not find field with id="${fieldId}"`,
-			);
-			return;
-		}
-
-		this._isValid = false;
-
-		// Find all rules (elements with data-pattern attribute)
-		this._rules = Array.from(this.querySelectorAll('[data-pattern]')).map(
-			(element) => ({
-				element,
-				pattern: element.getAttribute('data-pattern'),
-				regex: new RegExp(element.getAttribute('data-pattern')),
-			}),
-		);
-
-		if (this._rules.length === 0) {
-			console.warn(
-				'form-validation-list: No rules found with data-pattern attribute',
-			);
-			return;
-		}
-
-		// Set up ARIA relationship
-		this._setupAccessibility();
-
-		// Only add aria-atomic to list items; live announcements go through the live region
-		this._rules.forEach(({ element }) => {
-			FormValidationListElement.#ensureRulePresentation(element);
-			element.setAttribute('aria-atomic', 'true');
-		});
-
-		// Create the visually-hidden live region outside this described-by container.
-		if (!this._liveRegion) {
-			this._liveRegion = document.createElement('span');
-			this._liveRegion.setAttribute('aria-live', 'polite');
-			this._liveRegion.setAttribute('aria-atomic', 'true');
-			this._liveRegion.className = 'form-validation-list-live-region';
-			const liveRegionHost = this.parentElement || document.body;
-			liveRegionHost.appendChild(this._liveRegion);
-		}
-
-		// Sync icon glyphs and rule state text for this instance
-		this._updateRulePresentation();
-
-		// Attach blur handler to restore aria-describedby
-		if (!this._blurHandler) {
-			this._blurHandler = () => {
-				this._clearPendingBlurRestore();
-				this._pendingBlurRestoreTimeout = setTimeout(() => {
-					this._pendingBlurRestoreTimeout = null;
-					this._restoreDescribedBy();
-				}, FormValidationListElement.#describedByRestoreDelay);
-				if (this._liveRegion) {
-					this._liveRegion.textContent = '';
-				}
-			};
-			this._field.addEventListener('blur', this._blurHandler);
-		}
-
-		// Create validation handler
-		if (!this._validationHandler) {
-			this._validationHandler = () => {
-				this._scheduleValidation();
-			};
-		}
-
-		// Attach event listener
-		this._currentTriggerEvent = this.triggerEvent;
-		this._field.addEventListener(
-			this._currentTriggerEvent,
-			this._validationHandler,
-		);
-
-		// Run initial validation if field has a value
-		if (this._field.value) {
-			this._validateField();
-		}
-	}
-
-	_setupAccessibility() {
-		if (!this._field) return;
-
-		// Ensure this element has an ID
-		const listId = this.id || FormValidationListElement.#generateId();
-		if (!this.id) {
-			this.id = listId;
-		}
-
-		// Add this list to the field's aria-describedby
-		const existingDescribedBy =
-			this._field.getAttribute('aria-describedby');
-		if (existingDescribedBy) {
-			const describedByIds =
-				FormValidationListElement.#parseIdRefs(existingDescribedBy);
-			if (!describedByIds.includes(listId)) {
-				describedByIds.push(listId);
-				this._field.setAttribute(
-					'aria-describedby',
-					describedByIds.join(' '),
-				);
-			}
-		} else {
-			this._field.setAttribute('aria-describedby', listId);
-		}
-	}
-
-	_suspendDescribedBy() {
-		if (this._describedBySuspended || !this._field || !this.id) return;
-		this._removeOwnDescribedBy();
-		this._describedBySuspended = true;
-	}
-
-	_restoreDescribedBy() {
-		this._clearPendingBlurRestore();
-		if (!this._describedBySuspended || !this._field || !this.id) return;
-		const current = this._field.getAttribute('aria-describedby');
-		if (current) {
-			const ids = FormValidationListElement.#parseIdRefs(current);
-			if (!ids.includes(this.id)) {
-				ids.push(this.id);
-				this._field.setAttribute('aria-describedby', ids.join(' '));
-			}
-		} else {
-			this._field.setAttribute('aria-describedby', this.id);
-		}
-		this._describedBySuspended = false;
-	}
-
-	_removeOwnDescribedBy(field = this._field) {
-		if (!field || !this.id) return;
-		const current = field.getAttribute('aria-describedby');
-		if (!current) return;
-		const ids = FormValidationListElement.#parseIdRefs(current).filter(
-			(id) => id !== this.id,
-		);
-		if (ids.length > 0) {
-			field.setAttribute('aria-describedby', ids.join(' '));
-		} else {
-			field.removeAttribute('aria-describedby');
-		}
-	}
-
-	static #parseIdRefs(value) {
-		if (!value) return [];
-		return value.trim().split(/\s+/).filter(Boolean);
-	}
-
-	static #expandCountTemplate(template, matched, total) {
-		return String(template)
-			.replace(/\{matched\}/g, String(matched))
-			.replace(/\{total\}/g, String(total));
-	}
-
-	static #ensureRulePresentation(element) {
-		let iconElement = element.querySelector(
-			':scope > .form-validation-list-rule-icon',
-		);
-		if (!iconElement) {
-			iconElement = document.createElement('span');
-			iconElement.className = 'form-validation-list-rule-icon';
-			iconElement.setAttribute('aria-hidden', 'true');
-			element.prepend(iconElement);
-		}
-
-		let stateElement = element.querySelector(
-			':scope > .form-validation-list-rule-state',
-		);
-		if (!stateElement) {
-			stateElement = document.createElement('span');
-			stateElement.className = 'form-validation-list-rule-state';
-			iconElement.insertAdjacentElement('afterend', stateElement);
-		}
-
-		return { iconElement, stateElement };
-	}
-
-	_updateRulePresentation() {
-		if (this.ruleMatchedIcon) {
-			this.style.setProperty(
-				'--form-validation-list-rule-matched-icon',
-				JSON.stringify(this.ruleMatchedIcon),
-			);
-		} else {
-			this.style.removeProperty(
-				'--form-validation-list-rule-matched-icon',
-			);
-		}
-
-		if (this.ruleUnmatchedIcon) {
-			this.style.setProperty(
-				'--form-validation-list-rule-unmatched-icon',
-				JSON.stringify(this.ruleUnmatchedIcon),
-			);
-		} else {
-			this.style.removeProperty(
-				'--form-validation-list-rule-unmatched-icon',
-			);
-		}
-
-		for (let i = 0; i < this._rules.length; i++) {
-			const { element } = this._rules[i];
-			const { stateElement } =
-				FormValidationListElement.#ensureRulePresentation(element);
-			const isMatched = element.classList.contains(this.ruleMatchedClass);
-			stateElement.textContent = this._hasValue
-				? `${isMatched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
-				: '';
-		}
-	}
-
-	__handleFieldClassChange(oldValue, defaultClass, cacheKey) {
-		const previousClass =
-			oldValue === null ? defaultClass : oldValue || null;
-		this[cacheKey] = null;
-		if (this._field && previousClass) {
-			this._field.classList.remove(previousClass);
-		}
-		if (this._field) {
-			this._validateField();
-		}
-	}
-
-	__handleRuleClassChange(oldValue, defaultClass, cacheKey) {
-		const previousClass =
-			oldValue === null ? defaultClass : oldValue || null;
-		this[cacheKey] = null;
-		if (previousClass) {
-			for (let i = 0; i < this._rules.length; i++) {
-				this._rules[i].element.classList.remove(previousClass);
-			}
-		}
-		if (this._field) {
-			this._validateField();
-		}
-	}
-
-	__rebindValidationHandler(oldValue) {
-		if (!this._field || !this._validationHandler) {
-			return;
-		}
-		this._clearPendingInputThrottle();
-		const previousEvent = this._currentTriggerEvent || oldValue || 'input';
-		const nextEvent = this.triggerEvent;
-		if (previousEvent === nextEvent) {
-			return;
-		}
-		this._field.removeEventListener(previousEvent, this._validationHandler);
-		this._currentTriggerEvent = nextEvent;
-		this._field.addEventListener(nextEvent, this._validationHandler);
-	}
-
-	_clearPendingTimeouts() {
-		if (!this._pendingTimeouts.size) {
-			return;
-		}
-		for (const timeoutId of this._pendingTimeouts) {
-			clearTimeout(timeoutId);
-		}
-		this._pendingTimeouts.clear();
-	}
-
-	_clearPendingInputThrottle() {
-		if (this._pendingInputThrottleTimeout === null) {
-			return;
-		}
-		clearTimeout(this._pendingInputThrottleTimeout);
-		this._pendingInputThrottleTimeout = null;
-	}
-
-	_clearPendingBlurRestore() {
-		if (this._pendingBlurRestoreTimeout === null) {
-			return;
-		}
-		clearTimeout(this._pendingBlurRestoreTimeout);
-		this._pendingBlurRestoreTimeout = null;
-	}
-
-	_scheduleValidation() {
-		if (!this._field) {
-			return;
-		}
-
-		const listenerType = this._currentTriggerEvent || this.triggerEvent;
-		if (listenerType !== 'input') {
-			this._validateField();
-			return;
-		}
-
-		// Cancel pending restore when typing resumes.
-		this._clearPendingBlurRestore();
-
-		// Suspend aria-describedby as soon as the user starts typing
-		this._suspendDescribedBy();
-
-		const throttleDelay = this.inputThrottle;
-		if (throttleDelay <= 0) {
-			this._validateField();
-			return;
-		}
-
-		this._clearPendingInputThrottle();
-		this._pendingInputThrottleTimeout = setTimeout(() => {
-			this._pendingInputThrottleTimeout = null;
-			this._validateField();
-		}, throttleDelay);
-	}
-
-	_validateField() {
-		if (!this._field) return;
-
-		this._clearPendingTimeouts();
-
-		const value = this._field.value;
-		const rulesCount = this._rules.length;
-		let matchedRules = 0;
-		const delay = this.eachDelay;
-
-		// Track whether the field has a value to expose localized rule state text
-		const hasValue = value.length > 0;
-		if (hasValue !== this._hasValue) {
-			this._hasValue = hasValue;
-			this.classList.toggle('has-value', hasValue);
-		}
-
-		// Validate each rule
-		for (let i = 0; i < rulesCount; i++) {
-			const { element, regex } = this._rules[i];
-			const matched = regex.test(value);
-
-			if (matched) {
-				matchedRules++;
-			}
-
-			const applyClasses = () => {
-				this._toggleMatchedClasses(element, matched);
-			};
-
-			// Apply class changes with delay for visual cascade effect
-			if (delay > 0) {
-				const timeoutId = setTimeout(() => {
-					this._pendingTimeouts.delete(timeoutId);
-					applyClasses();
-				}, i * delay);
-				this._pendingTimeouts.add(timeoutId);
-			} else {
-				applyClasses();
-			}
-		}
-
-		// Update field validity
-		const isValid = matchedRules === rulesCount;
-		this._isValid = isValid;
-
-		// Cache class names for performance
-		const validClass = this.fieldValidClass;
-		const invalidClass = this.fieldInvalidClass;
-
-		// Update field classes
-		const fieldClassList = this._field.classList;
-		if (isValid) {
-			fieldClassList.add(validClass);
-			fieldClassList.remove(invalidClass);
-		} else {
-			fieldClassList.add(invalidClass);
-			fieldClassList.remove(validClass);
-		}
-
-		// Update live region with summary announcement
-		if (this._liveRegion) {
-			this._liveRegion.textContent =
-				FormValidationListElement.#expandCountTemplate(
-					this.announcement,
-					matchedRules,
-					rulesCount,
-				);
-		}
-
-		// Integrate with browser validation
-		this._updateFieldValidity(isValid, matchedRules);
-
-		// Fire custom event
-		this.dispatchEvent(
-			new CustomEvent('form-validation-list:validated', {
-				bubbles: true,
-				composed: true,
-				detail: {
-					isValid,
-					matchedRules,
-					totalRules: rulesCount,
-					field: this._field,
-				},
-			}),
-		);
-	}
-
-	_toggleMatchedClasses(element, matched) {
-		const { stateElement } =
-			FormValidationListElement.#ensureRulePresentation(element);
-		const classList = element.classList;
-		if (matched) {
-			classList.add(this.ruleMatchedClass);
-			classList.remove(this.ruleUnmatchedClass);
-		} else {
-			classList.add(this.ruleUnmatchedClass);
-			classList.remove(this.ruleMatchedClass);
-		}
-		stateElement.textContent = this._hasValue
-			? `${matched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
-			: '';
-	}
-
-	_updateFieldValidity(isValid, matchedRules) {
-		if (!this._field || !this._field.setCustomValidity) return;
-
-		if (isValid) {
-			this._field.setCustomValidity('');
-		} else {
-			const template =
-				this.validationMessage ||
-				'Please match all validation requirements ({matched} of {total})';
-			const message = FormValidationListElement.#expandCountTemplate(
-				template,
-				matchedRules,
-				this._rules.length,
-			);
-			this._field.setCustomValidity(message);
-		}
-	}
-
-	_cleanup() {
-		this._clearPendingBlurRestore();
-		this._clearPendingInputThrottle();
-		this._clearPendingTimeouts();
-
-		// Remove event listeners
-		if (this._field && this._validationHandler) {
-			const listenerType =
-				this._currentTriggerEvent || this.triggerEvent || 'input';
-			this._field.removeEventListener(
-				listenerType,
-				this._validationHandler,
-			);
-		}
-		if (this._field && this._blurHandler) {
-			this._field.removeEventListener('blur', this._blurHandler);
-		}
-
-		// Remove this element from the field's aria-describedby on cleanup
-		this._removeOwnDescribedBy();
-
-		// Clear custom validity
-		if (this._field && this._field.setCustomValidity) {
-			this._field.setCustomValidity('');
-		}
-
-		// Remove classes from field
-		if (this._field) {
-			this._field.classList.remove(
-				this.fieldValidClass,
-				this.fieldInvalidClass,
-			);
-		}
-
-		// Remove classes from rules
-		const rulesCount = this._rules.length;
-		const matchedClass = this.ruleMatchedClass;
-		const unmatchedClass = this.ruleUnmatchedClass;
-
-		for (let i = 0; i < rulesCount; i++) {
-			this._rules[i].element.classList.remove(
-				matchedClass,
-				unmatchedClass,
-			);
-		}
-
-		// Remove live region
-		if (this._liveRegion && this._liveRegion.parentNode) {
-			this._liveRegion.remove();
-		}
-
-		// Remove has-value class
-		this.classList.remove('has-value');
-		this.style.removeProperty('--form-validation-list-rule-matched-icon');
-		this.style.removeProperty('--form-validation-list-rule-unmatched-icon');
-
-		this._field = null;
-		this._rules = [];
-		this._validationHandler = null;
-		this._blurHandler = null;
-		this._liveRegion = null;
-		this._pendingBlurRestoreTimeout = null;
-		this._validClasses = null;
-		this._invalidClasses = null;
-		this._matchedClasses = null;
-		this._unmatchedClasses = null;
-		this._currentTriggerEvent = null;
-		this._describedBySuspended = false;
-		this._hasValue = false;
-		this._isValid = false;
-	}
-
-	/**
-	 * Manually trigger validation
-	 * @public
-	 */
-	validate() {
-		this._validateField();
-		return this._isValid;
-	}
-
-	/**
-	 * Get the current validation state
-	 * @public
-	 * @returns {boolean} Whether all rules are currently matched
-	 */
-	get isValid() {
-		return this._isValid;
-	}
+    document.head.appendChild(style);
+    FormValidationListElement.#stylesInjected = true;
+  }
+
+  static #generateId() {
+    return `form-validation-list-${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  constructor() {
+    super();
+    // Use light DOM instead of shadow DOM
+    this._field = null;
+    this._rules = [];
+    this._validationHandler = null;
+    this._isValid = false;
+    this._validClasses = null;
+    this._invalidClasses = null;
+    this._matchedClasses = null;
+    this._unmatchedClasses = null;
+    this._pendingTimeouts = new Set();
+    this._pendingInputThrottleTimeout = null;
+    this._pendingBlurRestoreTimeout = null;
+    this._currentTriggerEvent = null;
+    this._liveRegion = null;
+    this._blurHandler = null;
+    this._describedBySuspended = false;
+    this._describedByTargetId = null;
+    this._hasValue = false;
+  }
+
+  connectedCallback() {
+    this.__upgradeProperty('for');
+    this.__upgradeProperty('fieldId');
+    this.__upgradeProperty('triggerEvent');
+    this.__upgradeProperty('inputThrottle');
+    this.__upgradeProperty('eachDelay');
+    this.__upgradeProperty('fieldInvalidClass');
+    this.__upgradeProperty('fieldValidClass');
+    this.__upgradeProperty('ruleUnmatchedClass');
+    this.__upgradeProperty('ruleMatchedClass');
+    this.__upgradeProperty('ruleMatchedIcon');
+    this.__upgradeProperty('ruleUnmatchedIcon');
+    this.__upgradeProperty('ruleMatchedAlt');
+    this.__upgradeProperty('ruleUnmatchedAlt');
+    this.__upgradeProperty('announcement');
+    this.__upgradeProperty('validationMessage');
+    FormValidationListElement.#injectStyles();
+    this._setupValidation();
+  }
+
+  disconnectedCallback() {
+    this._cleanup();
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (oldValue === newValue) {
+      return;
+    }
+
+    switch (name) {
+      case 'for':
+        if (this.isConnected) {
+          this._cleanup();
+          this._setupValidation();
+        }
+        break;
+      case 'validation-message':
+        if (this._field) {
+          this._validateField();
+        }
+        break;
+      case 'trigger-event':
+        if (newValue !== null) {
+          const normalizedTriggerEvent =
+            FormValidationListElement.#normalizeTriggerEvent(
+              newValue,
+            );
+          if (newValue !== normalizedTriggerEvent) {
+            this.setAttribute(
+              'trigger-event',
+              normalizedTriggerEvent,
+            );
+            break;
+          }
+        }
+        this.__rebindValidationHandler(oldValue);
+        break;
+      case 'input-throttle':
+        this._clearPendingInputThrottle();
+        if (this._field) {
+          this._validateField();
+        }
+        break;
+      case 'each-delay':
+        this._clearPendingTimeouts();
+        if (this._field) {
+          this._validateField();
+        }
+        break;
+      case 'field-invalid-class':
+        this.__handleFieldClassChange(
+          oldValue,
+          'validation-invalid',
+          '_invalidClasses',
+        );
+        break;
+      case 'field-valid-class':
+        this.__handleFieldClassChange(
+          oldValue,
+          'validation-valid',
+          '_validClasses',
+        );
+        break;
+      case 'rule-unmatched-class':
+        this.__handleRuleClassChange(
+          oldValue,
+          'validation-unmatched',
+          '_unmatchedClasses',
+        );
+        break;
+      case 'rule-matched-class':
+        this.__handleRuleClassChange(
+          oldValue,
+          'validation-matched',
+          '_matchedClasses',
+        );
+        break;
+      case 'rule-matched-icon':
+      case 'rule-unmatched-icon':
+      case 'rule-matched-alt':
+      case 'rule-unmatched-alt':
+        this._updateRulePresentation();
+        break;
+      case 'announcement':
+        // No immediate action needed; next validation pass will use new template
+        break;
+      default:
+        break;
+    }
+  }
+
+  get ['for']() {
+    return this.fieldId;
+  }
+
+  set ['for'](value) {
+    this.fieldId = value;
+  }
+
+  get fieldId() {
+    return this.getAttribute('for');
+  }
+
+  set fieldId(value) {
+    if (value === null || value === undefined || value === '') {
+      this.removeAttribute('for');
+    } else {
+      this.setAttribute('for', String(value));
+    }
+  }
+
+  // Getters for configuration with cached class names
+  get triggerEvent() {
+    return FormValidationListElement.#normalizeTriggerEvent(
+      this.getAttribute('trigger-event'),
+    );
+  }
+
+  set triggerEvent(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value).trim();
+    if (normalized) {
+      this.setAttribute(
+        'trigger-event',
+        FormValidationListElement.#normalizeTriggerEvent(normalized),
+      );
+    } else {
+      this.removeAttribute('trigger-event');
+    }
+  }
+
+  get inputThrottle() {
+    const attrValue = this.getAttribute('input-throttle');
+    if (attrValue === null || attrValue === undefined || attrValue === '') {
+      return 250;
+    }
+    const parsed = Number(attrValue);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 250;
+  }
+
+  set inputThrottle(value) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      this.setAttribute('input-throttle', String(parsed));
+    } else {
+      this.removeAttribute('input-throttle');
+    }
+  }
+
+  get eachDelay() {
+    const attrValue = this.getAttribute('each-delay');
+    if (attrValue === null || attrValue === undefined || attrValue === '') {
+      return 150;
+    }
+    const parsed = Number(attrValue);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 150;
+  }
+
+  set eachDelay(value) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      this.setAttribute('each-delay', String(parsed));
+    } else {
+      this.removeAttribute('each-delay');
+    }
+  }
+
+  get fieldInvalidClass() {
+    if (this._invalidClasses === null) {
+      const attr = this.getAttribute('field-invalid-class');
+      this._invalidClasses = attr || 'validation-invalid';
+    }
+    return this._invalidClasses;
+  }
+
+  set fieldInvalidClass(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value).trim();
+    if (normalized) {
+      this.setAttribute('field-invalid-class', normalized);
+    } else {
+      this.removeAttribute('field-invalid-class');
+    }
+  }
+
+  get fieldValidClass() {
+    if (this._validClasses === null) {
+      const attr = this.getAttribute('field-valid-class');
+      this._validClasses = attr || 'validation-valid';
+    }
+    return this._validClasses;
+  }
+
+  set fieldValidClass(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value).trim();
+    if (normalized) {
+      this.setAttribute('field-valid-class', normalized);
+    } else {
+      this.removeAttribute('field-valid-class');
+    }
+  }
+
+  get ruleUnmatchedClass() {
+    if (this._unmatchedClasses === null) {
+      const attr = this.getAttribute('rule-unmatched-class');
+      this._unmatchedClasses = attr || 'validation-unmatched';
+    }
+    return this._unmatchedClasses;
+  }
+
+  set ruleUnmatchedClass(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value).trim();
+    if (normalized) {
+      this.setAttribute('rule-unmatched-class', normalized);
+    } else {
+      this.removeAttribute('rule-unmatched-class');
+    }
+  }
+
+  get ruleMatchedClass() {
+    if (this._matchedClasses === null) {
+      const attr = this.getAttribute('rule-matched-class');
+      this._matchedClasses = attr || 'validation-matched';
+    }
+    return this._matchedClasses;
+  }
+
+  set ruleMatchedClass(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value).trim();
+    if (normalized) {
+      this.setAttribute('rule-matched-class', normalized);
+    } else {
+      this.removeAttribute('rule-matched-class');
+    }
+  }
+
+  get validationMessage() {
+    return this.getAttribute('validation-message');
+  }
+
+  set validationMessage(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('validation-message', normalized);
+    } else {
+      this.removeAttribute('validation-message');
+    }
+  }
+
+  get ruleMatchedIcon() {
+    return this.getAttribute('rule-matched-icon');
+  }
+
+  set ruleMatchedIcon(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('rule-matched-icon', normalized);
+    } else {
+      this.removeAttribute('rule-matched-icon');
+    }
+  }
+
+  get ruleUnmatchedIcon() {
+    return this.getAttribute('rule-unmatched-icon');
+  }
+
+  set ruleUnmatchedIcon(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('rule-unmatched-icon', normalized);
+    } else {
+      this.removeAttribute('rule-unmatched-icon');
+    }
+  }
+
+  get ruleMatchedAlt() {
+    const attr = this.getAttribute('rule-matched-alt');
+    return attr !== null ? attr : 'Criteria met';
+  }
+
+  set ruleMatchedAlt(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('rule-matched-alt', normalized);
+    } else {
+      this.removeAttribute('rule-matched-alt');
+    }
+  }
+
+  get ruleUnmatchedAlt() {
+    const attr = this.getAttribute('rule-unmatched-alt');
+    return attr !== null ? attr : 'Criteria not met';
+  }
+
+  set ruleUnmatchedAlt(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('rule-unmatched-alt', normalized);
+    } else {
+      this.removeAttribute('rule-unmatched-alt');
+    }
+  }
+
+  get announcement() {
+    const attr = this.getAttribute('announcement');
+    return attr !== null ? attr : 'Criteria met: {matched} of {total}';
+  }
+
+  set announcement(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('announcement', normalized);
+    } else {
+      this.removeAttribute('announcement');
+    }
+  }
+
+  __upgradeProperty(prop) {
+    if (Object.prototype.hasOwnProperty.call(this, prop)) {
+      const value = this[prop];
+      delete this[prop];
+      this[prop] = value;
+    }
+  }
+
+  _setupValidation() {
+    this._clearPendingTimeouts();
+    const fieldId = this.fieldId;
+    if (!fieldId) return;
+
+    // Find the field
+    this._field = document.getElementById(fieldId);
+    if (!this._field) {
+      console.warn(
+        `form-validation-list: Could not find field with id="${fieldId}"`,
+      );
+      return;
+    }
+
+    this._isValid = false;
+
+    // Find all rules (elements with data-pattern attribute)
+    this._rules = Array.from(this.querySelectorAll('[data-pattern]')).map(
+      (element) => ({
+        element,
+        pattern: element.getAttribute('data-pattern'),
+        regex: new RegExp(element.getAttribute('data-pattern')),
+      }),
+    );
+
+    if (this._rules.length === 0) {
+      console.warn(
+        'form-validation-list: No rules found with data-pattern attribute',
+      );
+      return;
+    }
+
+    // Set up ARIA relationship
+    this._setupAccessibility();
+
+    // Only add aria-atomic to list items; live announcements go through the live region
+    this._rules.forEach(({ element }) => {
+      FormValidationListElement.#ensureRulePresentation(element);
+      element.setAttribute('aria-atomic', 'true');
+    });
+
+    // Create the visually-hidden live region as a sibling to the list within the component.
+    if (!this._liveRegion) {
+      this._liveRegion = document.createElement('span');
+      this._liveRegion.setAttribute('aria-live', 'polite');
+      this._liveRegion.setAttribute('aria-atomic', 'true');
+      this._liveRegion.className = 'form-validation-list-live-region';
+      this.appendChild(this._liveRegion);
+    }
+
+    // Sync icon glyphs and rule state text for this instance
+    this._updateRulePresentation();
+
+    // Attach blur handler to restore aria-describedby
+    if (!this._blurHandler) {
+      this._blurHandler = () => {
+        this._clearPendingBlurRestore();
+        this._pendingBlurRestoreTimeout = setTimeout(() => {
+          this._pendingBlurRestoreTimeout = null;
+          this._restoreDescribedBy();
+        }, FormValidationListElement.#describedByRestoreDelay);
+        if (this._liveRegion) {
+          this._liveRegion.textContent = '';
+        }
+      };
+      this._field.addEventListener('blur', this._blurHandler);
+    }
+
+    // Create validation handler
+    if (!this._validationHandler) {
+      this._validationHandler = () => {
+        this._scheduleValidation();
+      };
+    }
+
+    // Attach event listener
+    this._currentTriggerEvent = this.triggerEvent;
+    this._field.addEventListener(
+      this._currentTriggerEvent,
+      this._validationHandler,
+    );
+
+    // Run initial validation if field has a value
+    if (this._field.value) {
+      this._validateField();
+    }
+  }
+
+  _setupAccessibility() {
+    if (!this._field) return;
+
+    const describedByTarget = this.querySelector('ul, ol') || this;
+    if (!describedByTarget.id) {
+      describedByTarget.id = FormValidationListElement.#generateId();
+    }
+    const listId = describedByTarget.id;
+    this._describedByTargetId = listId;
+
+    // Add this list to the field's aria-describedby
+    const existingDescribedBy =
+      this._field.getAttribute('aria-describedby');
+    if (existingDescribedBy) {
+      const describedByIds =
+        FormValidationListElement.#parseIdRefs(existingDescribedBy);
+      if (!describedByIds.includes(listId)) {
+        describedByIds.push(listId);
+        this._field.setAttribute(
+          'aria-describedby',
+          describedByIds.join(' '),
+        );
+      }
+    } else {
+      this._field.setAttribute('aria-describedby', listId);
+    }
+  }
+
+  _suspendDescribedBy() {
+    if (
+      this._describedBySuspended ||
+      !this._field ||
+      !this._describedByTargetId
+    )
+      return;
+    this._removeOwnDescribedBy();
+    this._describedBySuspended = true;
+  }
+
+  _restoreDescribedBy() {
+    this._clearPendingBlurRestore();
+    if (
+      !this._describedBySuspended ||
+      !this._field ||
+      !this._describedByTargetId
+    )
+      return;
+    const current = this._field.getAttribute('aria-describedby');
+    if (current) {
+      const ids = FormValidationListElement.#parseIdRefs(current);
+      if (!ids.includes(this._describedByTargetId)) {
+        ids.push(this._describedByTargetId);
+        this._field.setAttribute('aria-describedby', ids.join(' '));
+      }
+    } else {
+      this._field.setAttribute(
+        'aria-describedby',
+        this._describedByTargetId,
+      );
+    }
+    this._describedBySuspended = false;
+  }
+
+  _removeOwnDescribedBy(field = this._field) {
+    if (!field || !this._describedByTargetId) return;
+    const current = field.getAttribute('aria-describedby');
+    if (!current) return;
+    const ids = FormValidationListElement.#parseIdRefs(current).filter(
+      (id) => id !== this._describedByTargetId,
+    );
+    if (ids.length > 0) {
+      field.setAttribute('aria-describedby', ids.join(' '));
+    } else {
+      field.removeAttribute('aria-describedby');
+    }
+  }
+
+  static #parseIdRefs(value) {
+    if (!value) return [];
+    return value.trim().split(/\s+/).filter(Boolean);
+  }
+
+  static #expandCountTemplate(template, matched, total) {
+    return String(template)
+      .replace(/\{matched\}/g, String(matched))
+      .replace(/\{total\}/g, String(total));
+  }
+
+  static #ensureRulePresentation(element) {
+    let iconElement = element.querySelector(
+      ':scope > .form-validation-list-rule-icon',
+    );
+    if (!iconElement) {
+      iconElement = document.createElement('span');
+      iconElement.className = 'form-validation-list-rule-icon';
+      iconElement.setAttribute('aria-hidden', 'true');
+      element.prepend(iconElement);
+    }
+
+    let stateElement = element.querySelector(
+      ':scope > .form-validation-list-rule-state',
+    );
+    if (!stateElement) {
+      stateElement = document.createElement('span');
+      stateElement.className = 'form-validation-list-rule-state';
+      iconElement.insertAdjacentElement('afterend', stateElement);
+    }
+
+    return { iconElement, stateElement };
+  }
+
+  _updateRulePresentation() {
+    if (this.ruleMatchedIcon) {
+      this.style.setProperty(
+        '--form-validation-list-rule-matched-icon',
+        JSON.stringify(this.ruleMatchedIcon),
+      );
+    } else {
+      this.style.removeProperty(
+        '--form-validation-list-rule-matched-icon',
+      );
+    }
+
+    if (this.ruleUnmatchedIcon) {
+      this.style.setProperty(
+        '--form-validation-list-rule-unmatched-icon',
+        JSON.stringify(this.ruleUnmatchedIcon),
+      );
+    } else {
+      this.style.removeProperty(
+        '--form-validation-list-rule-unmatched-icon',
+      );
+    }
+
+    for (let i = 0; i < this._rules.length; i++) {
+      const { element } = this._rules[i];
+      const { stateElement } =
+        FormValidationListElement.#ensureRulePresentation(element);
+      const isMatched = element.classList.contains(this.ruleMatchedClass);
+      stateElement.textContent = this._hasValue
+        ? `${isMatched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
+        : '';
+    }
+  }
+
+  __handleFieldClassChange(oldValue, defaultClass, cacheKey) {
+    const previousClass =
+      oldValue === null ? defaultClass : oldValue || null;
+    this[cacheKey] = null;
+    if (this._field && previousClass) {
+      this._field.classList.remove(previousClass);
+    }
+    if (this._field) {
+      this._validateField();
+    }
+  }
+
+  __handleRuleClassChange(oldValue, defaultClass, cacheKey) {
+    const previousClass =
+      oldValue === null ? defaultClass : oldValue || null;
+    this[cacheKey] = null;
+    if (previousClass) {
+      for (let i = 0; i < this._rules.length; i++) {
+        this._rules[i].element.classList.remove(previousClass);
+      }
+    }
+    if (this._field) {
+      this._validateField();
+    }
+  }
+
+  __rebindValidationHandler(oldValue) {
+    if (!this._field || !this._validationHandler) {
+      return;
+    }
+    this._clearPendingInputThrottle();
+    const previousEvent = this._currentTriggerEvent || oldValue || 'input';
+    const nextEvent = this.triggerEvent;
+    if (previousEvent === nextEvent) {
+      return;
+    }
+    this._field.removeEventListener(previousEvent, this._validationHandler);
+    this._currentTriggerEvent = nextEvent;
+    this._field.addEventListener(nextEvent, this._validationHandler);
+  }
+
+  _clearPendingTimeouts() {
+    if (!this._pendingTimeouts.size) {
+      return;
+    }
+    for (const timeoutId of this._pendingTimeouts) {
+      clearTimeout(timeoutId);
+    }
+    this._pendingTimeouts.clear();
+  }
+
+  _clearPendingInputThrottle() {
+    if (this._pendingInputThrottleTimeout === null) {
+      return;
+    }
+    clearTimeout(this._pendingInputThrottleTimeout);
+    this._pendingInputThrottleTimeout = null;
+  }
+
+  _clearPendingBlurRestore() {
+    if (this._pendingBlurRestoreTimeout === null) {
+      return;
+    }
+    clearTimeout(this._pendingBlurRestoreTimeout);
+    this._pendingBlurRestoreTimeout = null;
+  }
+
+  _scheduleValidation() {
+    if (!this._field) {
+      return;
+    }
+
+    const listenerType = this._currentTriggerEvent || this.triggerEvent;
+    if (listenerType !== 'input') {
+      this._validateField();
+      return;
+    }
+
+    // Cancel pending restore when typing resumes.
+    this._clearPendingBlurRestore();
+
+    // Suspend aria-describedby as soon as the user starts typing
+    this._suspendDescribedBy();
+
+    const throttleDelay = this.inputThrottle;
+    if (throttleDelay <= 0) {
+      this._validateField();
+      return;
+    }
+
+    this._clearPendingInputThrottle();
+    this._pendingInputThrottleTimeout = setTimeout(() => {
+      this._pendingInputThrottleTimeout = null;
+      this._validateField();
+    }, throttleDelay);
+  }
+
+  _validateField() {
+    if (!this._field) return;
+
+    this._clearPendingTimeouts();
+
+    const value = this._field.value;
+    const rulesCount = this._rules.length;
+    let matchedRules = 0;
+    const delay = this.eachDelay;
+
+    // Track whether the field has a value to expose localized rule state text
+    const hasValue = value.length > 0;
+    if (hasValue !== this._hasValue) {
+      this._hasValue = hasValue;
+      this.classList.toggle('has-value', hasValue);
+    }
+
+    // Validate each rule
+    for (let i = 0; i < rulesCount; i++) {
+      const { element, regex } = this._rules[i];
+      const matched = regex.test(value);
+
+      if (matched) {
+        matchedRules++;
+      }
+
+      const applyClasses = () => {
+        this._toggleMatchedClasses(element, matched);
+      };
+
+      // Apply class changes with delay for visual cascade effect
+      if (delay > 0) {
+        const timeoutId = setTimeout(() => {
+          this._pendingTimeouts.delete(timeoutId);
+          applyClasses();
+        }, i * delay);
+        this._pendingTimeouts.add(timeoutId);
+      } else {
+        applyClasses();
+      }
+    }
+
+    // Update field validity
+    const isValid = matchedRules === rulesCount;
+    this._isValid = isValid;
+
+    // Cache class names for performance
+    const validClass = this.fieldValidClass;
+    const invalidClass = this.fieldInvalidClass;
+
+    // Update field classes
+    const fieldClassList = this._field.classList;
+    if (isValid) {
+      fieldClassList.add(validClass);
+      fieldClassList.remove(invalidClass);
+    } else {
+      fieldClassList.add(invalidClass);
+      fieldClassList.remove(validClass);
+    }
+
+    // Update live region with summary announcement
+    if (this._liveRegion) {
+      this._liveRegion.textContent =
+        FormValidationListElement.#expandCountTemplate(
+          this.announcement,
+          matchedRules,
+          rulesCount,
+        );
+    }
+
+    // Integrate with browser validation
+    this._updateFieldValidity(isValid, matchedRules);
+
+    // Fire custom event
+    this.dispatchEvent(
+      new CustomEvent('form-validation-list:validated', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          isValid,
+          matchedRules,
+          totalRules: rulesCount,
+          field: this._field,
+        },
+      }),
+    );
+  }
+
+  _toggleMatchedClasses(element, matched) {
+    const { stateElement } =
+      FormValidationListElement.#ensureRulePresentation(element);
+    const classList = element.classList;
+    if (matched) {
+      classList.add(this.ruleMatchedClass);
+      classList.remove(this.ruleUnmatchedClass);
+    } else {
+      classList.add(this.ruleUnmatchedClass);
+      classList.remove(this.ruleMatchedClass);
+    }
+    stateElement.textContent = this._hasValue
+      ? `${matched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
+      : '';
+  }
+
+  _updateFieldValidity(isValid, matchedRules) {
+    if (!this._field || !this._field.setCustomValidity) return;
+
+    if (isValid) {
+      this._field.setCustomValidity('');
+    } else {
+      const template =
+        this.validationMessage ||
+        'Please match all validation requirements ({matched} of {total})';
+      const message = FormValidationListElement.#expandCountTemplate(
+        template,
+        matchedRules,
+        this._rules.length,
+      );
+      this._field.setCustomValidity(message);
+    }
+  }
+
+  _cleanup() {
+    this._clearPendingBlurRestore();
+    this._clearPendingInputThrottle();
+    this._clearPendingTimeouts();
+
+    // Remove event listeners
+    if (this._field && this._validationHandler) {
+      const listenerType =
+        this._currentTriggerEvent || this.triggerEvent || 'input';
+      this._field.removeEventListener(
+        listenerType,
+        this._validationHandler,
+      );
+    }
+    if (this._field && this._blurHandler) {
+      this._field.removeEventListener('blur', this._blurHandler);
+    }
+
+    // Remove this element from the field's aria-describedby on cleanup
+    this._removeOwnDescribedBy();
+
+    // Clear custom validity
+    if (this._field && this._field.setCustomValidity) {
+      this._field.setCustomValidity('');
+    }
+
+    // Remove classes from field
+    if (this._field) {
+      this._field.classList.remove(
+        this.fieldValidClass,
+        this.fieldInvalidClass,
+      );
+    }
+
+    // Remove classes from rules
+    const rulesCount = this._rules.length;
+    const matchedClass = this.ruleMatchedClass;
+    const unmatchedClass = this.ruleUnmatchedClass;
+
+    for (let i = 0; i < rulesCount; i++) {
+      this._rules[i].element.classList.remove(
+        matchedClass,
+        unmatchedClass,
+      );
+    }
+
+    // Remove live region
+    if (this._liveRegion && this._liveRegion.parentNode) {
+      this._liveRegion.remove();
+    }
+
+    // Remove has-value class
+    this.classList.remove('has-value');
+    this.style.removeProperty('--form-validation-list-rule-matched-icon');
+    this.style.removeProperty('--form-validation-list-rule-unmatched-icon');
+
+    this._field = null;
+    this._rules = [];
+    this._validationHandler = null;
+    this._blurHandler = null;
+    this._liveRegion = null;
+    this._pendingBlurRestoreTimeout = null;
+    this._validClasses = null;
+    this._invalidClasses = null;
+    this._matchedClasses = null;
+    this._unmatchedClasses = null;
+    this._currentTriggerEvent = null;
+    this._describedBySuspended = false;
+    this._describedByTargetId = null;
+    this._hasValue = false;
+    this._isValid = false;
+  }
+
+  /**
+   * Manually trigger validation
+   * @public
+   */
+  validate() {
+    this._validateField();
+    return this._isValid;
+  }
+
+  /**
+   * Get the current validation state
+   * @public
+   * @returns {boolean} Whether all rules are currently matched
+   */
+  get isValid() {
+    return this._isValid;
+  }
 }

--- a/form-validation-list.js
+++ b/form-validation-list.js
@@ -5,6 +5,7 @@
  *
  * @attr {string} for - The ID of the input field to validate
  * @attr {string} trigger-event - The event to trigger validation on (default: "input")
+ * @attr {number} input-throttle - Delay in milliseconds before running validation on input events (default: 250)
  * @attr {number} each-delay - Delay in milliseconds between each rule being classified (default: 150)
  * @attr {string} field-invalid-class - The class to apply when the field is invalid (default: "validation-invalid")
  * @attr {string} field-valid-class - The class to apply when the field is valid (default: "validation-valid")
@@ -30,6 +31,7 @@ export class FormValidationListElement extends HTMLElement {
 		return [
 			'for',
 			'trigger-event',
+			'input-throttle',
 			'each-delay',
 			'field-invalid-class',
 			'field-valid-class',
@@ -90,6 +92,7 @@ export class FormValidationListElement extends HTMLElement {
 		this._matchedClasses = null;
 		this._unmatchedClasses = null;
 		this._pendingTimeouts = new Set();
+		this._pendingInputThrottleTimeout = null;
 		this._currentTriggerEvent = null;
 	}
 
@@ -97,6 +100,7 @@ export class FormValidationListElement extends HTMLElement {
 		this.__upgradeProperty('for');
 		this.__upgradeProperty('fieldId');
 		this.__upgradeProperty('triggerEvent');
+		this.__upgradeProperty('inputThrottle');
 		this.__upgradeProperty('eachDelay');
 		this.__upgradeProperty('fieldInvalidClass');
 		this.__upgradeProperty('fieldValidClass');
@@ -130,6 +134,12 @@ export class FormValidationListElement extends HTMLElement {
 				break;
 			case 'trigger-event':
 				this.__rebindValidationHandler(oldValue);
+				break;
+			case 'input-throttle':
+				this._clearPendingInputThrottle();
+				if (this._field) {
+					this._validateField();
+				}
 				break;
 			case 'each-delay':
 				this._clearPendingTimeouts();
@@ -202,6 +212,24 @@ export class FormValidationListElement extends HTMLElement {
 			this.setAttribute('trigger-event', normalized);
 		} else {
 			this.removeAttribute('trigger-event');
+		}
+	}
+
+	get inputThrottle() {
+		const attrValue = this.getAttribute('input-throttle');
+		if (attrValue === null || attrValue === undefined || attrValue === '') {
+			return 250;
+		}
+		const parsed = Number(attrValue);
+		return Number.isFinite(parsed) && parsed >= 0 ? parsed : 250;
+	}
+
+	set inputThrottle(value) {
+		const parsed = Number(value);
+		if (Number.isFinite(parsed) && parsed >= 0) {
+			this.setAttribute('input-throttle', String(parsed));
+		} else {
+			this.removeAttribute('input-throttle');
 		}
 	}
 
@@ -361,7 +389,7 @@ export class FormValidationListElement extends HTMLElement {
 		// Create validation handler
 		if (!this._validationHandler) {
 			this._validationHandler = () => {
-				this._validateField();
+				this._scheduleValidation();
 			};
 		}
 
@@ -433,6 +461,7 @@ export class FormValidationListElement extends HTMLElement {
 		if (!this._field || !this._validationHandler) {
 			return;
 		}
+		this._clearPendingInputThrottle();
 		const previousEvent = this._currentTriggerEvent || oldValue || 'input';
 		const nextEvent = this.triggerEvent;
 		if (previousEvent === nextEvent) {
@@ -451,6 +480,38 @@ export class FormValidationListElement extends HTMLElement {
 			clearTimeout(timeoutId);
 		}
 		this._pendingTimeouts.clear();
+	}
+
+	_clearPendingInputThrottle() {
+		if (this._pendingInputThrottleTimeout === null) {
+			return;
+		}
+		clearTimeout(this._pendingInputThrottleTimeout);
+		this._pendingInputThrottleTimeout = null;
+	}
+
+	_scheduleValidation() {
+		if (!this._field) {
+			return;
+		}
+
+		const listenerType = this._currentTriggerEvent || this.triggerEvent;
+		if (listenerType !== 'input') {
+			this._validateField();
+			return;
+		}
+
+		const throttleDelay = this.inputThrottle;
+		if (throttleDelay <= 0) {
+			this._validateField();
+			return;
+		}
+
+		this._clearPendingInputThrottle();
+		this._pendingInputThrottleTimeout = setTimeout(() => {
+			this._pendingInputThrottleTimeout = null;
+			this._validateField();
+		}, throttleDelay);
 	}
 
 	_validateField() {
@@ -552,6 +613,7 @@ export class FormValidationListElement extends HTMLElement {
 	}
 
 	_cleanup() {
+		this._clearPendingInputThrottle();
 		this._clearPendingTimeouts();
 		// Remove event listener
 		if (this._field && this._validationHandler) {

--- a/form-validation-list.js
+++ b/form-validation-list.js
@@ -592,16 +592,7 @@ export class FormValidationListElement extends HTMLElement {
 
 	_suspendDescribedBy() {
 		if (this._describedBySuspended || !this._field || !this.id) return;
-		const current = this._field.getAttribute('aria-describedby');
-		if (!current) return;
-		const ids = FormValidationListElement.#parseIdRefs(current).filter(
-			(id) => id !== this.id,
-		);
-		if (ids.length > 0) {
-			this._field.setAttribute('aria-describedby', ids.join(' '));
-		} else {
-			this._field.removeAttribute('aria-describedby');
-		}
+		this._removeOwnDescribedBy();
 		this._describedBySuspended = true;
 	}
 
@@ -621,9 +612,29 @@ export class FormValidationListElement extends HTMLElement {
 		this._describedBySuspended = false;
 	}
 
+	_removeOwnDescribedBy(field = this._field) {
+		if (!field || !this.id) return;
+		const current = field.getAttribute('aria-describedby');
+		if (!current) return;
+		const ids = FormValidationListElement.#parseIdRefs(current).filter(
+			(id) => id !== this.id,
+		);
+		if (ids.length > 0) {
+			field.setAttribute('aria-describedby', ids.join(' '));
+		} else {
+			field.removeAttribute('aria-describedby');
+		}
+	}
+
 	static #parseIdRefs(value) {
 		if (!value) return [];
 		return value.trim().split(/\s+/).filter(Boolean);
+	}
+
+	static #expandCountTemplate(template, matched, total) {
+		return String(template)
+			.replace(/\{matched\}/g, String(matched))
+			.replace(/\{total\}/g, String(total));
 	}
 
 	static #ensureRulePresentation(element) {
@@ -839,10 +850,12 @@ export class FormValidationListElement extends HTMLElement {
 
 		// Update live region with summary announcement
 		if (this._liveRegion) {
-			const template = this.announcement;
-			this._liveRegion.textContent = template
-				.replace('{matched}', matchedRules)
-				.replace('{total}', rulesCount);
+			this._liveRegion.textContent =
+				FormValidationListElement.#expandCountTemplate(
+					this.announcement,
+					matchedRules,
+					rulesCount,
+				);
 		}
 
 		// Integrate with browser validation
@@ -888,9 +901,11 @@ export class FormValidationListElement extends HTMLElement {
 			const template =
 				this.validationMessage ||
 				'Please match all validation requirements ({matched} of {total})';
-			const message = template
-				.replace('{matched}', matchedRules)
-				.replace('{total}', this._rules.length);
+			const message = FormValidationListElement.#expandCountTemplate(
+				template,
+				matchedRules,
+				this._rules.length,
+			);
 			this._field.setCustomValidity(message);
 		}
 	}
@@ -913,8 +928,8 @@ export class FormValidationListElement extends HTMLElement {
 			this._field.removeEventListener('blur', this._blurHandler);
 		}
 
-		// Restore describedby before disconnecting
-		this._restoreDescribedBy();
+		// Remove this element from the field's aria-describedby on cleanup
+		this._removeOwnDescribedBy();
 
 		// Clear custom validity
 		if (this._field && this._field.setCustomValidity) {

--- a/form-validation-list.js
+++ b/form-validation-list.js
@@ -553,14 +553,24 @@ export class FormValidationListElement extends HTMLElement {
 		// Attach blur handler to restore aria-describedby
 		if (!this._blurHandler) {
 			this._blurHandler = () => {
+				// Cancel any pending throttle / per-rule delay timeouts and run
+				// a final synchronous validation (without live announcement)
+				// so rule state is up-to-date before restoring aria-describedby.
+				this._clearPendingInputThrottle();
+				this._clearPendingTimeouts();
+				if (this._field) {
+					this._validateField();
+				}
+
+				if (this._liveRegion) {
+					this._liveRegion.textContent = '';
+				}
+
 				this._clearPendingBlurRestore();
 				this._pendingBlurRestoreTimeout = setTimeout(() => {
 					this._pendingBlurRestoreTimeout = null;
 					this._restoreDescribedBy();
 				}, FormValidationListElement.#describedByRestoreDelay);
-				if (this._liveRegion) {
-					this._liveRegion.textContent = '';
-				}
 			};
 			this._field.addEventListener('blur', this._blurHandler);
 		}
@@ -887,14 +897,20 @@ export class FormValidationListElement extends HTMLElement {
 			fieldClassList.remove(validClass);
 		}
 
-		// Update live region with summary announcement
+		// Update live region with summary announcement only while typing
+		// (i.e. while aria-describedby is suspended). Keep it clear for
+		// blur-triggered or programmatic validation to avoid extra chatter.
 		if (this._liveRegion) {
-			this._liveRegion.textContent =
-				FormValidationListElement.#expandCountTemplate(
-					this.announcement,
-					matchedRules,
-					rulesCount,
-				);
+			if (this._describedBySuspended) {
+				this._liveRegion.textContent =
+					FormValidationListElement.#expandCountTemplate(
+						this.announcement,
+						matchedRules,
+						rulesCount,
+					);
+			} else {
+				this._liveRegion.textContent = '';
+			}
 		}
 
 		// Integrate with browser validation

--- a/form-validation-list.js
+++ b/form-validation-list.js
@@ -576,11 +576,13 @@ export class FormValidationListElement extends HTMLElement {
 		const existingDescribedBy =
 			this._field.getAttribute('aria-describedby');
 		if (existingDescribedBy) {
-			const describedByIds = existingDescribedBy.split(' ');
+			const describedByIds =
+				FormValidationListElement.#parseIdRefs(existingDescribedBy);
 			if (!describedByIds.includes(listId)) {
+				describedByIds.push(listId);
 				this._field.setAttribute(
 					'aria-describedby',
-					`${existingDescribedBy} ${listId}`,
+					describedByIds.join(' '),
 				);
 			}
 		} else {
@@ -592,7 +594,9 @@ export class FormValidationListElement extends HTMLElement {
 		if (this._describedBySuspended || !this._field || !this.id) return;
 		const current = this._field.getAttribute('aria-describedby');
 		if (!current) return;
-		const ids = current.split(' ').filter((id) => id !== this.id);
+		const ids = FormValidationListElement.#parseIdRefs(current).filter(
+			(id) => id !== this.id,
+		);
 		if (ids.length > 0) {
 			this._field.setAttribute('aria-describedby', ids.join(' '));
 		} else {
@@ -606,17 +610,20 @@ export class FormValidationListElement extends HTMLElement {
 		if (!this._describedBySuspended || !this._field || !this.id) return;
 		const current = this._field.getAttribute('aria-describedby');
 		if (current) {
-			const ids = current.split(' ');
+			const ids = FormValidationListElement.#parseIdRefs(current);
 			if (!ids.includes(this.id)) {
-				this._field.setAttribute(
-					'aria-describedby',
-					`${current} ${this.id}`,
-				);
+				ids.push(this.id);
+				this._field.setAttribute('aria-describedby', ids.join(' '));
 			}
 		} else {
 			this._field.setAttribute('aria-describedby', this.id);
 		}
 		this._describedBySuspended = false;
+	}
+
+	static #parseIdRefs(value) {
+		if (!value) return [];
+		return value.trim().split(/\s+/).filter(Boolean);
 	}
 
 	static #ensureRulePresentation(element) {

--- a/form-validation-list.js
+++ b/form-validation-list.js
@@ -11,21 +11,27 @@
  * @attr {string} field-valid-class - The class to apply when the field is valid (default: "validation-valid")
  * @attr {string} rule-unmatched-class - The class to apply when the rule's requirement are not met (default: "validation-unmatched")
  * @attr {string} rule-matched-class - The class to apply when the rule's requirement are met (default: "validation-matched")
+ * @attr {string} rule-matched-icon - Icon character for matched rules (default: "✓"); also configurable via --rule-matched-icon CSS custom property
+ * @attr {string} rule-unmatched-icon - Icon character for unmatched rules (default: "✗"); also configurable via --rule-unmatched-icon CSS custom property
+ * @attr {string} rule-matched-alt - Localized hidden state text for matched rules, used once the field has a value (default: "Criteria met")
+ * @attr {string} rule-unmatched-alt - Localized hidden state text for unmatched rules, used once the field has a value (default: "Criteria not met")
+ * @attr {string} announcement - Live region announcement template with {matched} and {total} placeholders (default: "Criteria met: {matched} of {total}")
  * @attr {string} validation-message - Custom validation message template with {matched} and {total} placeholders (default: "Please match all validation requirements ({matched} of {total})")
  *
  * @fires form-validation-list:validated - Fired when validation completes with details about matched/total rules
  *
  * @slot - Default slot for list items with data-pattern attributes
  *
- * @cssprop --validation-icon-matched - Content for the matched state icon (default: "✓")
- * @cssprop --validation-icon-unmatched - Content for the unmatched state icon (default: "✗")
- * @cssprop --validation-icon-size - Size of the validation icons (default: 1em)
- * @cssprop --validation-matched-color - Color for matched rules (default: green)
- * @cssprop --validation-unmatched-color - Color for unmatched rules (default: red)
+ * @cssprop --rule-matched-icon - Icon for matched state (default: "✓"). Alias: --validation-icon-matched
+ * @cssprop --rule-unmatched-icon - Icon for unmatched state (default: "✗"). Alias: --validation-icon-unmatched
+ * @cssprop --rule-icon-size - Size of the validation icons (default: 1em). Alias: --validation-icon-size
+ * @cssprop --rule-matched-color - Color for matched rules (default: green). Alias: --validation-matched-color
+ * @cssprop --rule-unmatched-color - Color for unmatched rules (default: red). Alias: --validation-unmatched-color
  */
 export class FormValidationListElement extends HTMLElement {
 	static #stylesInjected = false;
 	static #styleId = 'form-validation-list-styles';
+	static #describedByRestoreDelay = 200;
 
 	static get observedAttributes() {
 		return [
@@ -37,6 +43,11 @@ export class FormValidationListElement extends HTMLElement {
 			'field-valid-class',
 			'rule-unmatched-class',
 			'rule-matched-class',
+			'rule-matched-icon',
+			'rule-unmatched-icon',
+			'rule-matched-alt',
+			'rule-unmatched-alt',
+			'announcement',
 			'validation-message',
 		];
 	}
@@ -53,22 +64,49 @@ export class FormValidationListElement extends HTMLElement {
 				display: block;
 			}
 
-			form-validation-list [data-pattern]::before {
-				content: var(--validation-icon-unmatched, "✗");
+			.form-validation-list-rule-icon {
 				display: inline-block;
-				width: var(--validation-icon-size, 1em);
-				font-size: var(--validation-icon-size, 1em);
-				color: var(--validation-unmatched-color, red);
+				width: var(--rule-icon-size, var(--validation-icon-size, 1em));
+				font-size: var(--rule-icon-size, var(--validation-icon-size, 1em));
 			}
 
-			form-validation-list [data-pattern].validation-matched::before {
-				content: var(--validation-icon-matched, "✓");
-				color: var(--validation-matched-color, green);
+			.form-validation-list-rule-icon::before {
+				content: var(
+					--form-validation-list-rule-unmatched-icon,
+					var(--rule-unmatched-icon, var(--validation-icon-unmatched, "✗"))
+				);
+				display: inline-block;
+				color: var(--rule-unmatched-color, var(--validation-unmatched-color, red));
 			}
 
-			form-validation-list [data-pattern].validation-unmatched::before {
-				content: var(--validation-icon-unmatched, "✗");
-				color: var(--validation-unmatched-color, red);
+			form-validation-list [data-pattern].validation-matched > .form-validation-list-rule-icon::before {
+				content: var(
+					--form-validation-list-rule-matched-icon,
+					var(--rule-matched-icon, var(--validation-icon-matched, "✓"))
+				);
+				color: var(--rule-matched-color, var(--validation-matched-color, green));
+			}
+
+			.form-validation-list-rule-state {
+				clip: rect(0 0 0 0);
+				clip-path: inset(50%);
+				height: 1px;
+				margin: -1px;
+				overflow: hidden;
+				padding: 0;
+				position: absolute;
+				white-space: nowrap;
+				width: 1px;
+			}
+
+			.form-validation-list-live-region {
+				clip: rect(0 0 0 0);
+				clip-path: inset(50%);
+				height: 1px;
+				overflow: hidden;
+				position: absolute;
+				white-space: nowrap;
+				width: 1px;
 			}
 		`;
 
@@ -93,7 +131,12 @@ export class FormValidationListElement extends HTMLElement {
 		this._unmatchedClasses = null;
 		this._pendingTimeouts = new Set();
 		this._pendingInputThrottleTimeout = null;
+		this._pendingBlurRestoreTimeout = null;
 		this._currentTriggerEvent = null;
+		this._liveRegion = null;
+		this._blurHandler = null;
+		this._describedBySuspended = false;
+		this._hasValue = false;
 	}
 
 	connectedCallback() {
@@ -106,6 +149,11 @@ export class FormValidationListElement extends HTMLElement {
 		this.__upgradeProperty('fieldValidClass');
 		this.__upgradeProperty('ruleUnmatchedClass');
 		this.__upgradeProperty('ruleMatchedClass');
+		this.__upgradeProperty('ruleMatchedIcon');
+		this.__upgradeProperty('ruleUnmatchedIcon');
+		this.__upgradeProperty('ruleMatchedAlt');
+		this.__upgradeProperty('ruleUnmatchedAlt');
+		this.__upgradeProperty('announcement');
 		this.__upgradeProperty('validationMessage');
 		FormValidationListElement.#injectStyles();
 		this._setupValidation();
@@ -174,6 +222,15 @@ export class FormValidationListElement extends HTMLElement {
 					'validation-matched',
 					'_matchedClasses',
 				);
+				break;
+			case 'rule-matched-icon':
+			case 'rule-unmatched-icon':
+			case 'rule-matched-alt':
+			case 'rule-unmatched-alt':
+				this._updateRulePresentation();
+				break;
+			case 'announcement':
+				// No immediate action needed; next validation pass will use new template
 				break;
 			default:
 				break;
@@ -337,6 +394,79 @@ export class FormValidationListElement extends HTMLElement {
 		}
 	}
 
+	get ruleMatchedIcon() {
+		return this.getAttribute('rule-matched-icon');
+	}
+
+	set ruleMatchedIcon(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-matched-icon', normalized);
+		} else {
+			this.removeAttribute('rule-matched-icon');
+		}
+	}
+
+	get ruleUnmatchedIcon() {
+		return this.getAttribute('rule-unmatched-icon');
+	}
+
+	set ruleUnmatchedIcon(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-unmatched-icon', normalized);
+		} else {
+			this.removeAttribute('rule-unmatched-icon');
+		}
+	}
+
+	get ruleMatchedAlt() {
+		const attr = this.getAttribute('rule-matched-alt');
+		return attr !== null ? attr : 'Criteria met';
+	}
+
+	set ruleMatchedAlt(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-matched-alt', normalized);
+		} else {
+			this.removeAttribute('rule-matched-alt');
+		}
+	}
+
+	get ruleUnmatchedAlt() {
+		const attr = this.getAttribute('rule-unmatched-alt');
+		return attr !== null ? attr : 'Criteria not met';
+	}
+
+	set ruleUnmatchedAlt(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('rule-unmatched-alt', normalized);
+		} else {
+			this.removeAttribute('rule-unmatched-alt');
+		}
+	}
+
+	get announcement() {
+		const attr = this.getAttribute('announcement');
+		return attr !== null ? attr : 'Criteria met: {matched} of {total}';
+	}
+
+	set announcement(value) {
+		const normalized =
+			value === null || value === undefined ? '' : String(value);
+		if (normalized) {
+			this.setAttribute('announcement', normalized);
+		} else {
+			this.removeAttribute('announcement');
+		}
+	}
+
 	__upgradeProperty(prop) {
 		if (Object.prototype.hasOwnProperty.call(this, prop)) {
 			const value = this[prop];
@@ -380,11 +510,38 @@ export class FormValidationListElement extends HTMLElement {
 		// Set up ARIA relationship
 		this._setupAccessibility();
 
-		// Keep native list semantics and only add live-region attributes
+		// Only add aria-atomic to list items; live announcements go through the live region
 		this._rules.forEach(({ element }) => {
-			element.setAttribute('aria-live', 'polite');
+			FormValidationListElement.#ensureRulePresentation(element);
 			element.setAttribute('aria-atomic', 'true');
 		});
+
+		// Create the visually-hidden live region
+		if (!this._liveRegion) {
+			this._liveRegion = document.createElement('span');
+			this._liveRegion.setAttribute('aria-live', 'polite');
+			this._liveRegion.setAttribute('aria-atomic', 'true');
+			this._liveRegion.className = 'form-validation-list-live-region';
+			this.appendChild(this._liveRegion);
+		}
+
+		// Sync icon glyphs and rule state text for this instance
+		this._updateRulePresentation();
+
+		// Attach blur handler to restore aria-describedby
+		if (!this._blurHandler) {
+			this._blurHandler = () => {
+				this._clearPendingBlurRestore();
+				this._pendingBlurRestoreTimeout = setTimeout(() => {
+					this._pendingBlurRestoreTimeout = null;
+					this._restoreDescribedBy();
+				}, FormValidationListElement.#describedByRestoreDelay);
+				if (this._liveRegion) {
+					this._liveRegion.textContent = '';
+				}
+			};
+			this._field.addEventListener('blur', this._blurHandler);
+		}
 
 		// Create validation handler
 		if (!this._validationHandler) {
@@ -428,6 +585,94 @@ export class FormValidationListElement extends HTMLElement {
 			}
 		} else {
 			this._field.setAttribute('aria-describedby', listId);
+		}
+	}
+
+	_suspendDescribedBy() {
+		if (this._describedBySuspended || !this._field || !this.id) return;
+		const current = this._field.getAttribute('aria-describedby');
+		if (!current) return;
+		const ids = current.split(' ').filter((id) => id !== this.id);
+		if (ids.length > 0) {
+			this._field.setAttribute('aria-describedby', ids.join(' '));
+		} else {
+			this._field.removeAttribute('aria-describedby');
+		}
+		this._describedBySuspended = true;
+	}
+
+	_restoreDescribedBy() {
+		this._clearPendingBlurRestore();
+		if (!this._describedBySuspended || !this._field || !this.id) return;
+		const current = this._field.getAttribute('aria-describedby');
+		if (current) {
+			const ids = current.split(' ');
+			if (!ids.includes(this.id)) {
+				this._field.setAttribute(
+					'aria-describedby',
+					`${current} ${this.id}`,
+				);
+			}
+		} else {
+			this._field.setAttribute('aria-describedby', this.id);
+		}
+		this._describedBySuspended = false;
+	}
+
+	static #ensureRulePresentation(element) {
+		let iconElement = element.querySelector(
+			':scope > .form-validation-list-rule-icon',
+		);
+		if (!iconElement) {
+			iconElement = document.createElement('span');
+			iconElement.className = 'form-validation-list-rule-icon';
+			iconElement.setAttribute('aria-hidden', 'true');
+			element.prepend(iconElement);
+		}
+
+		let stateElement = element.querySelector(
+			':scope > .form-validation-list-rule-state',
+		);
+		if (!stateElement) {
+			stateElement = document.createElement('span');
+			stateElement.className = 'form-validation-list-rule-state';
+			iconElement.insertAdjacentElement('afterend', stateElement);
+		}
+
+		return { iconElement, stateElement };
+	}
+
+	_updateRulePresentation() {
+		if (this.ruleMatchedIcon) {
+			this.style.setProperty(
+				'--form-validation-list-rule-matched-icon',
+				JSON.stringify(this.ruleMatchedIcon),
+			);
+		} else {
+			this.style.removeProperty(
+				'--form-validation-list-rule-matched-icon',
+			);
+		}
+
+		if (this.ruleUnmatchedIcon) {
+			this.style.setProperty(
+				'--form-validation-list-rule-unmatched-icon',
+				JSON.stringify(this.ruleUnmatchedIcon),
+			);
+		} else {
+			this.style.removeProperty(
+				'--form-validation-list-rule-unmatched-icon',
+			);
+		}
+
+		for (let i = 0; i < this._rules.length; i++) {
+			const { element } = this._rules[i];
+			const { stateElement } =
+				FormValidationListElement.#ensureRulePresentation(element);
+			const isMatched = element.classList.contains(this.ruleMatchedClass);
+			stateElement.textContent = this._hasValue
+				? `${isMatched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
+				: '';
 		}
 	}
 
@@ -490,6 +735,14 @@ export class FormValidationListElement extends HTMLElement {
 		this._pendingInputThrottleTimeout = null;
 	}
 
+	_clearPendingBlurRestore() {
+		if (this._pendingBlurRestoreTimeout === null) {
+			return;
+		}
+		clearTimeout(this._pendingBlurRestoreTimeout);
+		this._pendingBlurRestoreTimeout = null;
+	}
+
 	_scheduleValidation() {
 		if (!this._field) {
 			return;
@@ -500,6 +753,9 @@ export class FormValidationListElement extends HTMLElement {
 			this._validateField();
 			return;
 		}
+
+		// Suspend aria-describedby as soon as the user starts typing
+		this._suspendDescribedBy();
 
 		const throttleDelay = this.inputThrottle;
 		if (throttleDelay <= 0) {
@@ -523,6 +779,13 @@ export class FormValidationListElement extends HTMLElement {
 		const rulesCount = this._rules.length;
 		let matchedRules = 0;
 		const delay = this.eachDelay;
+
+		// Track whether the field has a value to expose localized rule state text
+		const hasValue = value.length > 0;
+		if (hasValue !== this._hasValue) {
+			this._hasValue = hasValue;
+			this.classList.toggle('has-value', hasValue);
+		}
 
 		// Validate each rule
 		for (let i = 0; i < rulesCount; i++) {
@@ -567,6 +830,14 @@ export class FormValidationListElement extends HTMLElement {
 			fieldClassList.remove(validClass);
 		}
 
+		// Update live region with summary announcement
+		if (this._liveRegion) {
+			const template = this.announcement;
+			this._liveRegion.textContent = template
+				.replace('{matched}', matchedRules)
+				.replace('{total}', rulesCount);
+		}
+
 		// Integrate with browser validation
 		this._updateFieldValidity(isValid, matchedRules);
 
@@ -586,6 +857,8 @@ export class FormValidationListElement extends HTMLElement {
 	}
 
 	_toggleMatchedClasses(element, matched) {
+		const { stateElement } =
+			FormValidationListElement.#ensureRulePresentation(element);
 		const classList = element.classList;
 		if (matched) {
 			classList.add(this.ruleMatchedClass);
@@ -594,6 +867,9 @@ export class FormValidationListElement extends HTMLElement {
 			classList.add(this.ruleUnmatchedClass);
 			classList.remove(this.ruleMatchedClass);
 		}
+		stateElement.textContent = this._hasValue
+			? `${matched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
+			: '';
 	}
 
 	_updateFieldValidity(isValid, matchedRules) {
@@ -613,9 +889,11 @@ export class FormValidationListElement extends HTMLElement {
 	}
 
 	_cleanup() {
+		this._clearPendingBlurRestore();
 		this._clearPendingInputThrottle();
 		this._clearPendingTimeouts();
-		// Remove event listener
+
+		// Remove event listeners
 		if (this._field && this._validationHandler) {
 			const listenerType =
 				this._currentTriggerEvent || this.triggerEvent || 'input';
@@ -624,6 +902,12 @@ export class FormValidationListElement extends HTMLElement {
 				this._validationHandler,
 			);
 		}
+		if (this._field && this._blurHandler) {
+			this._field.removeEventListener('blur', this._blurHandler);
+		}
+
+		// Restore describedby before disconnecting
+		this._restoreDescribedBy();
 
 		// Clear custom validity
 		if (this._field && this._field.setCustomValidity) {
@@ -650,14 +934,29 @@ export class FormValidationListElement extends HTMLElement {
 			);
 		}
 
+		// Remove live region
+		if (this._liveRegion && this._liveRegion.parentNode) {
+			this._liveRegion.remove();
+		}
+
+		// Remove has-value class
+		this.classList.remove('has-value');
+		this.style.removeProperty('--form-validation-list-rule-matched-icon');
+		this.style.removeProperty('--form-validation-list-rule-unmatched-icon');
+
 		this._field = null;
 		this._rules = [];
 		this._validationHandler = null;
+		this._blurHandler = null;
+		this._liveRegion = null;
+		this._pendingBlurRestoreTimeout = null;
 		this._validClasses = null;
 		this._invalidClasses = null;
 		this._matchedClasses = null;
 		this._unmatchedClasses = null;
 		this._currentTriggerEvent = null;
+		this._describedBySuspended = false;
+		this._hasValue = false;
 		this._isValid = false;
 	}
 

--- a/form-validation-list.js
+++ b/form-validation-list.js
@@ -103,7 +103,6 @@ export class FormValidationListElement extends HTMLElement {
 		this.__upgradeProperty('ruleUnmatchedClass');
 		this.__upgradeProperty('ruleMatchedClass');
 		this.__upgradeProperty('validationMessage');
-		this.setAttribute('role', 'list');
 		FormValidationListElement.#injectStyles();
 		this._setupValidation();
 	}
@@ -353,9 +352,8 @@ export class FormValidationListElement extends HTMLElement {
 		// Set up ARIA relationship
 		this._setupAccessibility();
 
-		// Add role to rule items
+		// Keep native list semantics and only add live-region attributes
 		this._rules.forEach(({ element }) => {
-			element.setAttribute('role', 'listitem');
 			element.setAttribute('aria-live', 'polite');
 			element.setAttribute('aria-atomic', 'true');
 		});

--- a/form-validation-list.js
+++ b/form-validation-list.js
@@ -4,7 +4,7 @@
  * @element form-validation-list
  *
  * @attr {string} for - The ID of the input field to validate
- * @attr {string} trigger-event - The event to trigger validation on (default: "input")
+ * @attr {string} trigger-event - The event to trigger validation on ("input" or "blur", default: "input")
  * @attr {number} input-throttle - Delay in milliseconds before running validation on input events (default: 250)
  * @attr {number} each-delay - Delay in milliseconds between each rule being classified (default: 150)
  * @attr {string} field-invalid-class - The class to apply when the field is invalid (default: "validation-invalid")
@@ -29,37 +29,40 @@
  * @cssprop --rule-unmatched-color - Color for unmatched rules (default: red). Alias: --validation-unmatched-color
  */
 export class FormValidationListElement extends HTMLElement {
-	static #stylesInjected = false;
-	static #styleId = 'form-validation-list-styles';
-	static #describedByRestoreDelay = 200;
+  static #stylesInjected = false;
+  static #styleId = 'form-validation-list-styles';
+  static #describedByRestoreDelay = 200;
+  static #normalizeTriggerEvent(value) {
+    return value === 'blur' ? 'blur' : 'input';
+  }
 
-	static get observedAttributes() {
-		return [
-			'for',
-			'trigger-event',
-			'input-throttle',
-			'each-delay',
-			'field-invalid-class',
-			'field-valid-class',
-			'rule-unmatched-class',
-			'rule-matched-class',
-			'rule-matched-icon',
-			'rule-unmatched-icon',
-			'rule-matched-alt',
-			'rule-unmatched-alt',
-			'announcement',
-			'validation-message',
-		];
-	}
+  static get observedAttributes() {
+    return [
+      'for',
+      'trigger-event',
+      'input-throttle',
+      'each-delay',
+      'field-invalid-class',
+      'field-valid-class',
+      'rule-unmatched-class',
+      'rule-matched-class',
+      'rule-matched-icon',
+      'rule-unmatched-icon',
+      'rule-matched-alt',
+      'rule-unmatched-alt',
+      'announcement',
+      'validation-message',
+    ];
+  }
 
-	static #injectStyles() {
-		if (FormValidationListElement.#stylesInjected) {
-			return;
-		}
+  static #injectStyles() {
+    if (FormValidationListElement.#stylesInjected) {
+      return;
+    }
 
-		const style = document.createElement('style');
-		style.id = FormValidationListElement.#styleId;
-		style.textContent = `
+    const style = document.createElement('style');
+    style.id = FormValidationListElement.#styleId;
+    style.textContent = `
 			form-validation-list {
 				display: block;
 			}
@@ -110,893 +113,913 @@ export class FormValidationListElement extends HTMLElement {
 			}
 		`;
 
-		document.head.appendChild(style);
-		FormValidationListElement.#stylesInjected = true;
-	}
-
-	static #generateId() {
-		return `form-validation-list-${Math.random().toString(36).substr(2, 9)}`;
-	}
-
-	constructor() {
-		super();
-		// Use light DOM instead of shadow DOM
-		this._field = null;
-		this._rules = [];
-		this._validationHandler = null;
-		this._isValid = false;
-		this._validClasses = null;
-		this._invalidClasses = null;
-		this._matchedClasses = null;
-		this._unmatchedClasses = null;
-		this._pendingTimeouts = new Set();
-		this._pendingInputThrottleTimeout = null;
-		this._pendingBlurRestoreTimeout = null;
-		this._currentTriggerEvent = null;
-		this._liveRegion = null;
-		this._blurHandler = null;
-		this._describedBySuspended = false;
-		this._hasValue = false;
-	}
-
-	connectedCallback() {
-		this.__upgradeProperty('for');
-		this.__upgradeProperty('fieldId');
-		this.__upgradeProperty('triggerEvent');
-		this.__upgradeProperty('inputThrottle');
-		this.__upgradeProperty('eachDelay');
-		this.__upgradeProperty('fieldInvalidClass');
-		this.__upgradeProperty('fieldValidClass');
-		this.__upgradeProperty('ruleUnmatchedClass');
-		this.__upgradeProperty('ruleMatchedClass');
-		this.__upgradeProperty('ruleMatchedIcon');
-		this.__upgradeProperty('ruleUnmatchedIcon');
-		this.__upgradeProperty('ruleMatchedAlt');
-		this.__upgradeProperty('ruleUnmatchedAlt');
-		this.__upgradeProperty('announcement');
-		this.__upgradeProperty('validationMessage');
-		FormValidationListElement.#injectStyles();
-		this._setupValidation();
-	}
-
-	disconnectedCallback() {
-		this._cleanup();
-	}
-
-	attributeChangedCallback(name, oldValue, newValue) {
-		if (oldValue === newValue) {
-			return;
-		}
-
-		switch (name) {
-			case 'for':
-				if (this.isConnected) {
-					this._cleanup();
-					this._setupValidation();
-				}
-				break;
-			case 'validation-message':
-				if (this._field) {
-					this._validateField();
-				}
-				break;
-			case 'trigger-event':
-				this.__rebindValidationHandler(oldValue);
-				break;
-			case 'input-throttle':
-				this._clearPendingInputThrottle();
-				if (this._field) {
-					this._validateField();
-				}
-				break;
-			case 'each-delay':
-				this._clearPendingTimeouts();
-				if (this._field) {
-					this._validateField();
-				}
-				break;
-			case 'field-invalid-class':
-				this.__handleFieldClassChange(
-					oldValue,
-					'validation-invalid',
-					'_invalidClasses',
-				);
-				break;
-			case 'field-valid-class':
-				this.__handleFieldClassChange(
-					oldValue,
-					'validation-valid',
-					'_validClasses',
-				);
-				break;
-			case 'rule-unmatched-class':
-				this.__handleRuleClassChange(
-					oldValue,
-					'validation-unmatched',
-					'_unmatchedClasses',
-				);
-				break;
-			case 'rule-matched-class':
-				this.__handleRuleClassChange(
-					oldValue,
-					'validation-matched',
-					'_matchedClasses',
-				);
-				break;
-			case 'rule-matched-icon':
-			case 'rule-unmatched-icon':
-			case 'rule-matched-alt':
-			case 'rule-unmatched-alt':
-				this._updateRulePresentation();
-				break;
-			case 'announcement':
-				// No immediate action needed; next validation pass will use new template
-				break;
-			default:
-				break;
-		}
-	}
-
-	get ['for']() {
-		return this.fieldId;
-	}
-
-	set ['for'](value) {
-		this.fieldId = value;
-	}
-
-	get fieldId() {
-		return this.getAttribute('for');
-	}
-
-	set fieldId(value) {
-		if (value === null || value === undefined || value === '') {
-			this.removeAttribute('for');
-		} else {
-			this.setAttribute('for', String(value));
-		}
-	}
-
-	// Getters for configuration with cached class names
-	get triggerEvent() {
-		return this.getAttribute('trigger-event') || 'input';
-	}
-
-	set triggerEvent(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value).trim();
-		if (normalized) {
-			this.setAttribute('trigger-event', normalized);
-		} else {
-			this.removeAttribute('trigger-event');
-		}
-	}
-
-	get inputThrottle() {
-		const attrValue = this.getAttribute('input-throttle');
-		if (attrValue === null || attrValue === undefined || attrValue === '') {
-			return 250;
-		}
-		const parsed = Number(attrValue);
-		return Number.isFinite(parsed) && parsed >= 0 ? parsed : 250;
-	}
-
-	set inputThrottle(value) {
-		const parsed = Number(value);
-		if (Number.isFinite(parsed) && parsed >= 0) {
-			this.setAttribute('input-throttle', String(parsed));
-		} else {
-			this.removeAttribute('input-throttle');
-		}
-	}
-
-	get eachDelay() {
-		const attrValue = this.getAttribute('each-delay');
-		if (attrValue === null || attrValue === undefined || attrValue === '') {
-			return 150;
-		}
-		const parsed = Number(attrValue);
-		return Number.isFinite(parsed) && parsed >= 0 ? parsed : 150;
-	}
-
-	set eachDelay(value) {
-		const parsed = Number(value);
-		if (Number.isFinite(parsed) && parsed >= 0) {
-			this.setAttribute('each-delay', String(parsed));
-		} else {
-			this.removeAttribute('each-delay');
-		}
-	}
-
-	get fieldInvalidClass() {
-		if (this._invalidClasses === null) {
-			const attr = this.getAttribute('field-invalid-class');
-			this._invalidClasses = attr || 'validation-invalid';
-		}
-		return this._invalidClasses;
-	}
-
-	set fieldInvalidClass(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value).trim();
-		if (normalized) {
-			this.setAttribute('field-invalid-class', normalized);
-		} else {
-			this.removeAttribute('field-invalid-class');
-		}
-	}
-
-	get fieldValidClass() {
-		if (this._validClasses === null) {
-			const attr = this.getAttribute('field-valid-class');
-			this._validClasses = attr || 'validation-valid';
-		}
-		return this._validClasses;
-	}
-
-	set fieldValidClass(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value).trim();
-		if (normalized) {
-			this.setAttribute('field-valid-class', normalized);
-		} else {
-			this.removeAttribute('field-valid-class');
-		}
-	}
-
-	get ruleUnmatchedClass() {
-		if (this._unmatchedClasses === null) {
-			const attr = this.getAttribute('rule-unmatched-class');
-			this._unmatchedClasses = attr || 'validation-unmatched';
-		}
-		return this._unmatchedClasses;
-	}
-
-	set ruleUnmatchedClass(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value).trim();
-		if (normalized) {
-			this.setAttribute('rule-unmatched-class', normalized);
-		} else {
-			this.removeAttribute('rule-unmatched-class');
-		}
-	}
-
-	get ruleMatchedClass() {
-		if (this._matchedClasses === null) {
-			const attr = this.getAttribute('rule-matched-class');
-			this._matchedClasses = attr || 'validation-matched';
-		}
-		return this._matchedClasses;
-	}
-
-	set ruleMatchedClass(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value).trim();
-		if (normalized) {
-			this.setAttribute('rule-matched-class', normalized);
-		} else {
-			this.removeAttribute('rule-matched-class');
-		}
-	}
-
-	get validationMessage() {
-		return this.getAttribute('validation-message');
-	}
-
-	set validationMessage(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('validation-message', normalized);
-		} else {
-			this.removeAttribute('validation-message');
-		}
-	}
-
-	get ruleMatchedIcon() {
-		return this.getAttribute('rule-matched-icon');
-	}
-
-	set ruleMatchedIcon(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('rule-matched-icon', normalized);
-		} else {
-			this.removeAttribute('rule-matched-icon');
-		}
-	}
-
-	get ruleUnmatchedIcon() {
-		return this.getAttribute('rule-unmatched-icon');
-	}
-
-	set ruleUnmatchedIcon(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('rule-unmatched-icon', normalized);
-		} else {
-			this.removeAttribute('rule-unmatched-icon');
-		}
-	}
-
-	get ruleMatchedAlt() {
-		const attr = this.getAttribute('rule-matched-alt');
-		return attr !== null ? attr : 'Criteria met';
-	}
-
-	set ruleMatchedAlt(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('rule-matched-alt', normalized);
-		} else {
-			this.removeAttribute('rule-matched-alt');
-		}
-	}
-
-	get ruleUnmatchedAlt() {
-		const attr = this.getAttribute('rule-unmatched-alt');
-		return attr !== null ? attr : 'Criteria not met';
-	}
-
-	set ruleUnmatchedAlt(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('rule-unmatched-alt', normalized);
-		} else {
-			this.removeAttribute('rule-unmatched-alt');
-		}
-	}
-
-	get announcement() {
-		const attr = this.getAttribute('announcement');
-		return attr !== null ? attr : 'Criteria met: {matched} of {total}';
-	}
-
-	set announcement(value) {
-		const normalized =
-			value === null || value === undefined ? '' : String(value);
-		if (normalized) {
-			this.setAttribute('announcement', normalized);
-		} else {
-			this.removeAttribute('announcement');
-		}
-	}
-
-	__upgradeProperty(prop) {
-		if (Object.prototype.hasOwnProperty.call(this, prop)) {
-			const value = this[prop];
-			delete this[prop];
-			this[prop] = value;
-		}
-	}
-
-	_setupValidation() {
-		this._clearPendingTimeouts();
-		const fieldId = this.fieldId;
-		if (!fieldId) return;
-
-		// Find the field
-		this._field = document.getElementById(fieldId);
-		if (!this._field) {
-			console.warn(
-				`form-validation-list: Could not find field with id="${fieldId}"`,
-			);
-			return;
-		}
-
-		this._isValid = false;
-
-		// Find all rules (elements with data-pattern attribute)
-		this._rules = Array.from(this.querySelectorAll('[data-pattern]')).map(
-			(element) => ({
-				element,
-				pattern: element.getAttribute('data-pattern'),
-				regex: new RegExp(element.getAttribute('data-pattern')),
-			}),
-		);
-
-		if (this._rules.length === 0) {
-			console.warn(
-				'form-validation-list: No rules found with data-pattern attribute',
-			);
-			return;
-		}
-
-		// Set up ARIA relationship
-		this._setupAccessibility();
-
-		// Only add aria-atomic to list items; live announcements go through the live region
-		this._rules.forEach(({ element }) => {
-			FormValidationListElement.#ensureRulePresentation(element);
-			element.setAttribute('aria-atomic', 'true');
-		});
-
-		// Create the visually-hidden live region
-		if (!this._liveRegion) {
-			this._liveRegion = document.createElement('span');
-			this._liveRegion.setAttribute('aria-live', 'polite');
-			this._liveRegion.setAttribute('aria-atomic', 'true');
-			this._liveRegion.className = 'form-validation-list-live-region';
-			this.appendChild(this._liveRegion);
-		}
-
-		// Sync icon glyphs and rule state text for this instance
-		this._updateRulePresentation();
-
-		// Attach blur handler to restore aria-describedby
-		if (!this._blurHandler) {
-			this._blurHandler = () => {
-				this._clearPendingBlurRestore();
-				this._pendingBlurRestoreTimeout = setTimeout(() => {
-					this._pendingBlurRestoreTimeout = null;
-					this._restoreDescribedBy();
-				}, FormValidationListElement.#describedByRestoreDelay);
-				if (this._liveRegion) {
-					this._liveRegion.textContent = '';
-				}
-			};
-			this._field.addEventListener('blur', this._blurHandler);
-		}
-
-		// Create validation handler
-		if (!this._validationHandler) {
-			this._validationHandler = () => {
-				this._scheduleValidation();
-			};
-		}
-
-		// Attach event listener
-		this._currentTriggerEvent = this.triggerEvent;
-		this._field.addEventListener(
-			this._currentTriggerEvent,
-			this._validationHandler,
-		);
-
-		// Run initial validation if field has a value
-		if (this._field.value) {
-			this._validateField();
-		}
-	}
-
-	_setupAccessibility() {
-		if (!this._field) return;
-
-		// Ensure this element has an ID
-		const listId = this.id || FormValidationListElement.#generateId();
-		if (!this.id) {
-			this.id = listId;
-		}
-
-		// Add this list to the field's aria-describedby
-		const existingDescribedBy =
-			this._field.getAttribute('aria-describedby');
-		if (existingDescribedBy) {
-			const describedByIds =
-				FormValidationListElement.#parseIdRefs(existingDescribedBy);
-			if (!describedByIds.includes(listId)) {
-				describedByIds.push(listId);
-				this._field.setAttribute(
-					'aria-describedby',
-					describedByIds.join(' '),
-				);
-			}
-		} else {
-			this._field.setAttribute('aria-describedby', listId);
-		}
-	}
-
-	_suspendDescribedBy() {
-		if (this._describedBySuspended || !this._field || !this.id) return;
-		this._removeOwnDescribedBy();
-		this._describedBySuspended = true;
-	}
-
-	_restoreDescribedBy() {
-		this._clearPendingBlurRestore();
-		if (!this._describedBySuspended || !this._field || !this.id) return;
-		const current = this._field.getAttribute('aria-describedby');
-		if (current) {
-			const ids = FormValidationListElement.#parseIdRefs(current);
-			if (!ids.includes(this.id)) {
-				ids.push(this.id);
-				this._field.setAttribute('aria-describedby', ids.join(' '));
-			}
-		} else {
-			this._field.setAttribute('aria-describedby', this.id);
-		}
-		this._describedBySuspended = false;
-	}
-
-	_removeOwnDescribedBy(field = this._field) {
-		if (!field || !this.id) return;
-		const current = field.getAttribute('aria-describedby');
-		if (!current) return;
-		const ids = FormValidationListElement.#parseIdRefs(current).filter(
-			(id) => id !== this.id,
-		);
-		if (ids.length > 0) {
-			field.setAttribute('aria-describedby', ids.join(' '));
-		} else {
-			field.removeAttribute('aria-describedby');
-		}
-	}
-
-	static #parseIdRefs(value) {
-		if (!value) return [];
-		return value.trim().split(/\s+/).filter(Boolean);
-	}
-
-	static #expandCountTemplate(template, matched, total) {
-		return String(template)
-			.replace(/\{matched\}/g, String(matched))
-			.replace(/\{total\}/g, String(total));
-	}
-
-	static #ensureRulePresentation(element) {
-		let iconElement = element.querySelector(
-			':scope > .form-validation-list-rule-icon',
-		);
-		if (!iconElement) {
-			iconElement = document.createElement('span');
-			iconElement.className = 'form-validation-list-rule-icon';
-			iconElement.setAttribute('aria-hidden', 'true');
-			element.prepend(iconElement);
-		}
-
-		let stateElement = element.querySelector(
-			':scope > .form-validation-list-rule-state',
-		);
-		if (!stateElement) {
-			stateElement = document.createElement('span');
-			stateElement.className = 'form-validation-list-rule-state';
-			iconElement.insertAdjacentElement('afterend', stateElement);
-		}
-
-		return { iconElement, stateElement };
-	}
-
-	_updateRulePresentation() {
-		if (this.ruleMatchedIcon) {
-			this.style.setProperty(
-				'--form-validation-list-rule-matched-icon',
-				JSON.stringify(this.ruleMatchedIcon),
-			);
-		} else {
-			this.style.removeProperty(
-				'--form-validation-list-rule-matched-icon',
-			);
-		}
-
-		if (this.ruleUnmatchedIcon) {
-			this.style.setProperty(
-				'--form-validation-list-rule-unmatched-icon',
-				JSON.stringify(this.ruleUnmatchedIcon),
-			);
-		} else {
-			this.style.removeProperty(
-				'--form-validation-list-rule-unmatched-icon',
-			);
-		}
-
-		for (let i = 0; i < this._rules.length; i++) {
-			const { element } = this._rules[i];
-			const { stateElement } =
-				FormValidationListElement.#ensureRulePresentation(element);
-			const isMatched = element.classList.contains(this.ruleMatchedClass);
-			stateElement.textContent = this._hasValue
-				? `${isMatched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
-				: '';
-		}
-	}
-
-	__handleFieldClassChange(oldValue, defaultClass, cacheKey) {
-		const previousClass =
-			oldValue === null ? defaultClass : oldValue || null;
-		this[cacheKey] = null;
-		if (this._field && previousClass) {
-			this._field.classList.remove(previousClass);
-		}
-		if (this._field) {
-			this._validateField();
-		}
-	}
-
-	__handleRuleClassChange(oldValue, defaultClass, cacheKey) {
-		const previousClass =
-			oldValue === null ? defaultClass : oldValue || null;
-		this[cacheKey] = null;
-		if (previousClass) {
-			for (let i = 0; i < this._rules.length; i++) {
-				this._rules[i].element.classList.remove(previousClass);
-			}
-		}
-		if (this._field) {
-			this._validateField();
-		}
-	}
-
-	__rebindValidationHandler(oldValue) {
-		if (!this._field || !this._validationHandler) {
-			return;
-		}
-		this._clearPendingInputThrottle();
-		const previousEvent = this._currentTriggerEvent || oldValue || 'input';
-		const nextEvent = this.triggerEvent;
-		if (previousEvent === nextEvent) {
-			return;
-		}
-		this._field.removeEventListener(previousEvent, this._validationHandler);
-		this._currentTriggerEvent = nextEvent;
-		this._field.addEventListener(nextEvent, this._validationHandler);
-	}
-
-	_clearPendingTimeouts() {
-		if (!this._pendingTimeouts.size) {
-			return;
-		}
-		for (const timeoutId of this._pendingTimeouts) {
-			clearTimeout(timeoutId);
-		}
-		this._pendingTimeouts.clear();
-	}
-
-	_clearPendingInputThrottle() {
-		if (this._pendingInputThrottleTimeout === null) {
-			return;
-		}
-		clearTimeout(this._pendingInputThrottleTimeout);
-		this._pendingInputThrottleTimeout = null;
-	}
-
-	_clearPendingBlurRestore() {
-		if (this._pendingBlurRestoreTimeout === null) {
-			return;
-		}
-		clearTimeout(this._pendingBlurRestoreTimeout);
-		this._pendingBlurRestoreTimeout = null;
-	}
-
-	_scheduleValidation() {
-		if (!this._field) {
-			return;
-		}
-
-		const listenerType = this._currentTriggerEvent || this.triggerEvent;
-		if (listenerType !== 'input') {
-			this._validateField();
-			return;
-		}
-
-		// Suspend aria-describedby as soon as the user starts typing
-		this._suspendDescribedBy();
-
-		const throttleDelay = this.inputThrottle;
-		if (throttleDelay <= 0) {
-			this._validateField();
-			return;
-		}
-
-		this._clearPendingInputThrottle();
-		this._pendingInputThrottleTimeout = setTimeout(() => {
-			this._pendingInputThrottleTimeout = null;
-			this._validateField();
-		}, throttleDelay);
-	}
-
-	_validateField() {
-		if (!this._field) return;
-
-		this._clearPendingTimeouts();
-
-		const value = this._field.value;
-		const rulesCount = this._rules.length;
-		let matchedRules = 0;
-		const delay = this.eachDelay;
-
-		// Track whether the field has a value to expose localized rule state text
-		const hasValue = value.length > 0;
-		if (hasValue !== this._hasValue) {
-			this._hasValue = hasValue;
-			this.classList.toggle('has-value', hasValue);
-		}
-
-		// Validate each rule
-		for (let i = 0; i < rulesCount; i++) {
-			const { element, regex } = this._rules[i];
-			const matched = regex.test(value);
-
-			if (matched) {
-				matchedRules++;
-			}
-
-			const applyClasses = () => {
-				this._toggleMatchedClasses(element, matched);
-			};
-
-			// Apply class changes with delay for visual cascade effect
-			if (delay > 0) {
-				const timeoutId = setTimeout(() => {
-					this._pendingTimeouts.delete(timeoutId);
-					applyClasses();
-				}, i * delay);
-				this._pendingTimeouts.add(timeoutId);
-			} else {
-				applyClasses();
-			}
-		}
-
-		// Update field validity
-		const isValid = matchedRules === rulesCount;
-		this._isValid = isValid;
-
-		// Cache class names for performance
-		const validClass = this.fieldValidClass;
-		const invalidClass = this.fieldInvalidClass;
-
-		// Update field classes
-		const fieldClassList = this._field.classList;
-		if (isValid) {
-			fieldClassList.add(validClass);
-			fieldClassList.remove(invalidClass);
-		} else {
-			fieldClassList.add(invalidClass);
-			fieldClassList.remove(validClass);
-		}
-
-		// Update live region with summary announcement
-		if (this._liveRegion) {
-			this._liveRegion.textContent =
-				FormValidationListElement.#expandCountTemplate(
-					this.announcement,
-					matchedRules,
-					rulesCount,
-				);
-		}
-
-		// Integrate with browser validation
-		this._updateFieldValidity(isValid, matchedRules);
-
-		// Fire custom event
-		this.dispatchEvent(
-			new CustomEvent('form-validation-list:validated', {
-				bubbles: true,
-				composed: true,
-				detail: {
-					isValid,
-					matchedRules,
-					totalRules: rulesCount,
-					field: this._field,
-				},
-			}),
-		);
-	}
-
-	_toggleMatchedClasses(element, matched) {
-		const { stateElement } =
-			FormValidationListElement.#ensureRulePresentation(element);
-		const classList = element.classList;
-		if (matched) {
-			classList.add(this.ruleMatchedClass);
-			classList.remove(this.ruleUnmatchedClass);
-		} else {
-			classList.add(this.ruleUnmatchedClass);
-			classList.remove(this.ruleMatchedClass);
-		}
-		stateElement.textContent = this._hasValue
-			? `${matched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
-			: '';
-	}
-
-	_updateFieldValidity(isValid, matchedRules) {
-		if (!this._field || !this._field.setCustomValidity) return;
-
-		if (isValid) {
-			this._field.setCustomValidity('');
-		} else {
-			const template =
-				this.validationMessage ||
-				'Please match all validation requirements ({matched} of {total})';
-			const message = FormValidationListElement.#expandCountTemplate(
-				template,
-				matchedRules,
-				this._rules.length,
-			);
-			this._field.setCustomValidity(message);
-		}
-	}
-
-	_cleanup() {
-		this._clearPendingBlurRestore();
-		this._clearPendingInputThrottle();
-		this._clearPendingTimeouts();
-
-		// Remove event listeners
-		if (this._field && this._validationHandler) {
-			const listenerType =
-				this._currentTriggerEvent || this.triggerEvent || 'input';
-			this._field.removeEventListener(
-				listenerType,
-				this._validationHandler,
-			);
-		}
-		if (this._field && this._blurHandler) {
-			this._field.removeEventListener('blur', this._blurHandler);
-		}
-
-		// Remove this element from the field's aria-describedby on cleanup
-		this._removeOwnDescribedBy();
-
-		// Clear custom validity
-		if (this._field && this._field.setCustomValidity) {
-			this._field.setCustomValidity('');
-		}
-
-		// Remove classes from field
-		if (this._field) {
-			this._field.classList.remove(
-				this.fieldValidClass,
-				this.fieldInvalidClass,
-			);
-		}
-
-		// Remove classes from rules
-		const rulesCount = this._rules.length;
-		const matchedClass = this.ruleMatchedClass;
-		const unmatchedClass = this.ruleUnmatchedClass;
-
-		for (let i = 0; i < rulesCount; i++) {
-			this._rules[i].element.classList.remove(
-				matchedClass,
-				unmatchedClass,
-			);
-		}
-
-		// Remove live region
-		if (this._liveRegion && this._liveRegion.parentNode) {
-			this._liveRegion.remove();
-		}
-
-		// Remove has-value class
-		this.classList.remove('has-value');
-		this.style.removeProperty('--form-validation-list-rule-matched-icon');
-		this.style.removeProperty('--form-validation-list-rule-unmatched-icon');
-
-		this._field = null;
-		this._rules = [];
-		this._validationHandler = null;
-		this._blurHandler = null;
-		this._liveRegion = null;
-		this._pendingBlurRestoreTimeout = null;
-		this._validClasses = null;
-		this._invalidClasses = null;
-		this._matchedClasses = null;
-		this._unmatchedClasses = null;
-		this._currentTriggerEvent = null;
-		this._describedBySuspended = false;
-		this._hasValue = false;
-		this._isValid = false;
-	}
-
-	/**
-	 * Manually trigger validation
-	 * @public
-	 */
-	validate() {
-		this._validateField();
-		return this._isValid;
-	}
-
-	/**
-	 * Get the current validation state
-	 * @public
-	 * @returns {boolean} Whether all rules are currently matched
-	 */
-	get isValid() {
-		return this._isValid;
-	}
+    document.head.appendChild(style);
+    FormValidationListElement.#stylesInjected = true;
+  }
+
+  static #generateId() {
+    return `form-validation-list-${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  constructor() {
+    super();
+    // Use light DOM instead of shadow DOM
+    this._field = null;
+    this._rules = [];
+    this._validationHandler = null;
+    this._isValid = false;
+    this._validClasses = null;
+    this._invalidClasses = null;
+    this._matchedClasses = null;
+    this._unmatchedClasses = null;
+    this._pendingTimeouts = new Set();
+    this._pendingInputThrottleTimeout = null;
+    this._pendingBlurRestoreTimeout = null;
+    this._currentTriggerEvent = null;
+    this._liveRegion = null;
+    this._blurHandler = null;
+    this._describedBySuspended = false;
+    this._hasValue = false;
+  }
+
+  connectedCallback() {
+    this.__upgradeProperty('for');
+    this.__upgradeProperty('fieldId');
+    this.__upgradeProperty('triggerEvent');
+    this.__upgradeProperty('inputThrottle');
+    this.__upgradeProperty('eachDelay');
+    this.__upgradeProperty('fieldInvalidClass');
+    this.__upgradeProperty('fieldValidClass');
+    this.__upgradeProperty('ruleUnmatchedClass');
+    this.__upgradeProperty('ruleMatchedClass');
+    this.__upgradeProperty('ruleMatchedIcon');
+    this.__upgradeProperty('ruleUnmatchedIcon');
+    this.__upgradeProperty('ruleMatchedAlt');
+    this.__upgradeProperty('ruleUnmatchedAlt');
+    this.__upgradeProperty('announcement');
+    this.__upgradeProperty('validationMessage');
+    FormValidationListElement.#injectStyles();
+    this._setupValidation();
+  }
+
+  disconnectedCallback() {
+    this._cleanup();
+  }
+
+  attributeChangedCallback(name, oldValue, newValue) {
+    if (oldValue === newValue) {
+      return;
+    }
+
+    switch (name) {
+      case 'for':
+        if (this.isConnected) {
+          this._cleanup();
+          this._setupValidation();
+        }
+        break;
+      case 'validation-message':
+        if (this._field) {
+          this._validateField();
+        }
+        break;
+      case 'trigger-event':
+        if (newValue !== null) {
+          const normalizedTriggerEvent =
+            FormValidationListElement.#normalizeTriggerEvent(newValue);
+          if (newValue !== normalizedTriggerEvent) {
+            this.setAttribute(
+              'trigger-event',
+              normalizedTriggerEvent,
+            );
+            break;
+          }
+        }
+        this.__rebindValidationHandler(oldValue);
+        break;
+      case 'input-throttle':
+        this._clearPendingInputThrottle();
+        if (this._field) {
+          this._validateField();
+        }
+        break;
+      case 'each-delay':
+        this._clearPendingTimeouts();
+        if (this._field) {
+          this._validateField();
+        }
+        break;
+      case 'field-invalid-class':
+        this.__handleFieldClassChange(
+          oldValue,
+          'validation-invalid',
+          '_invalidClasses',
+        );
+        break;
+      case 'field-valid-class':
+        this.__handleFieldClassChange(
+          oldValue,
+          'validation-valid',
+          '_validClasses',
+        );
+        break;
+      case 'rule-unmatched-class':
+        this.__handleRuleClassChange(
+          oldValue,
+          'validation-unmatched',
+          '_unmatchedClasses',
+        );
+        break;
+      case 'rule-matched-class':
+        this.__handleRuleClassChange(
+          oldValue,
+          'validation-matched',
+          '_matchedClasses',
+        );
+        break;
+      case 'rule-matched-icon':
+      case 'rule-unmatched-icon':
+      case 'rule-matched-alt':
+      case 'rule-unmatched-alt':
+        this._updateRulePresentation();
+        break;
+      case 'announcement':
+        // No immediate action needed; next validation pass will use new template
+        break;
+      default:
+        break;
+    }
+  }
+
+  get ['for']() {
+    return this.fieldId;
+  }
+
+  set ['for'](value) {
+    this.fieldId = value;
+  }
+
+  get fieldId() {
+    return this.getAttribute('for');
+  }
+
+  set fieldId(value) {
+    if (value === null || value === undefined || value === '') {
+      this.removeAttribute('for');
+    } else {
+      this.setAttribute('for', String(value));
+    }
+  }
+
+  // Getters for configuration with cached class names
+  get triggerEvent() {
+    return FormValidationListElement.#normalizeTriggerEvent(
+      this.getAttribute('trigger-event'),
+    );
+  }
+
+  set triggerEvent(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value).trim();
+    if (normalized) {
+      this.setAttribute(
+        'trigger-event',
+        FormValidationListElement.#normalizeTriggerEvent(normalized),
+      );
+    } else {
+      this.removeAttribute('trigger-event');
+    }
+  }
+
+  get inputThrottle() {
+    const attrValue = this.getAttribute('input-throttle');
+    if (attrValue === null || attrValue === undefined || attrValue === '') {
+      return 250;
+    }
+    const parsed = Number(attrValue);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 250;
+  }
+
+  set inputThrottle(value) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      this.setAttribute('input-throttle', String(parsed));
+    } else {
+      this.removeAttribute('input-throttle');
+    }
+  }
+
+  get eachDelay() {
+    const attrValue = this.getAttribute('each-delay');
+    if (attrValue === null || attrValue === undefined || attrValue === '') {
+      return 150;
+    }
+    const parsed = Number(attrValue);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 150;
+  }
+
+  set eachDelay(value) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      this.setAttribute('each-delay', String(parsed));
+    } else {
+      this.removeAttribute('each-delay');
+    }
+  }
+
+  get fieldInvalidClass() {
+    if (this._invalidClasses === null) {
+      const attr = this.getAttribute('field-invalid-class');
+      this._invalidClasses = attr || 'validation-invalid';
+    }
+    return this._invalidClasses;
+  }
+
+  set fieldInvalidClass(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value).trim();
+    if (normalized) {
+      this.setAttribute('field-invalid-class', normalized);
+    } else {
+      this.removeAttribute('field-invalid-class');
+    }
+  }
+
+  get fieldValidClass() {
+    if (this._validClasses === null) {
+      const attr = this.getAttribute('field-valid-class');
+      this._validClasses = attr || 'validation-valid';
+    }
+    return this._validClasses;
+  }
+
+  set fieldValidClass(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value).trim();
+    if (normalized) {
+      this.setAttribute('field-valid-class', normalized);
+    } else {
+      this.removeAttribute('field-valid-class');
+    }
+  }
+
+  get ruleUnmatchedClass() {
+    if (this._unmatchedClasses === null) {
+      const attr = this.getAttribute('rule-unmatched-class');
+      this._unmatchedClasses = attr || 'validation-unmatched';
+    }
+    return this._unmatchedClasses;
+  }
+
+  set ruleUnmatchedClass(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value).trim();
+    if (normalized) {
+      this.setAttribute('rule-unmatched-class', normalized);
+    } else {
+      this.removeAttribute('rule-unmatched-class');
+    }
+  }
+
+  get ruleMatchedClass() {
+    if (this._matchedClasses === null) {
+      const attr = this.getAttribute('rule-matched-class');
+      this._matchedClasses = attr || 'validation-matched';
+    }
+    return this._matchedClasses;
+  }
+
+  set ruleMatchedClass(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value).trim();
+    if (normalized) {
+      this.setAttribute('rule-matched-class', normalized);
+    } else {
+      this.removeAttribute('rule-matched-class');
+    }
+  }
+
+  get validationMessage() {
+    return this.getAttribute('validation-message');
+  }
+
+  set validationMessage(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('validation-message', normalized);
+    } else {
+      this.removeAttribute('validation-message');
+    }
+  }
+
+  get ruleMatchedIcon() {
+    return this.getAttribute('rule-matched-icon');
+  }
+
+  set ruleMatchedIcon(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('rule-matched-icon', normalized);
+    } else {
+      this.removeAttribute('rule-matched-icon');
+    }
+  }
+
+  get ruleUnmatchedIcon() {
+    return this.getAttribute('rule-unmatched-icon');
+  }
+
+  set ruleUnmatchedIcon(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('rule-unmatched-icon', normalized);
+    } else {
+      this.removeAttribute('rule-unmatched-icon');
+    }
+  }
+
+  get ruleMatchedAlt() {
+    const attr = this.getAttribute('rule-matched-alt');
+    return attr !== null ? attr : 'Criteria met';
+  }
+
+  set ruleMatchedAlt(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('rule-matched-alt', normalized);
+    } else {
+      this.removeAttribute('rule-matched-alt');
+    }
+  }
+
+  get ruleUnmatchedAlt() {
+    const attr = this.getAttribute('rule-unmatched-alt');
+    return attr !== null ? attr : 'Criteria not met';
+  }
+
+  set ruleUnmatchedAlt(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('rule-unmatched-alt', normalized);
+    } else {
+      this.removeAttribute('rule-unmatched-alt');
+    }
+  }
+
+  get announcement() {
+    const attr = this.getAttribute('announcement');
+    return attr !== null ? attr : 'Criteria met: {matched} of {total}';
+  }
+
+  set announcement(value) {
+    const normalized =
+      value === null || value === undefined ? '' : String(value);
+    if (normalized) {
+      this.setAttribute('announcement', normalized);
+    } else {
+      this.removeAttribute('announcement');
+    }
+  }
+
+  __upgradeProperty(prop) {
+    if (Object.prototype.hasOwnProperty.call(this, prop)) {
+      const value = this[prop];
+      delete this[prop];
+      this[prop] = value;
+    }
+  }
+
+  _setupValidation() {
+    this._clearPendingTimeouts();
+    const fieldId = this.fieldId;
+    if (!fieldId) return;
+
+    // Find the field
+    this._field = document.getElementById(fieldId);
+    if (!this._field) {
+      console.warn(
+        `form-validation-list: Could not find field with id="${fieldId}"`,
+      );
+      return;
+    }
+
+    this._isValid = false;
+
+    // Find all rules (elements with data-pattern attribute)
+    this._rules = Array.from(this.querySelectorAll('[data-pattern]')).map(
+      (element) => ({
+        element,
+        pattern: element.getAttribute('data-pattern'),
+        regex: new RegExp(element.getAttribute('data-pattern')),
+      }),
+    );
+
+    if (this._rules.length === 0) {
+      console.warn(
+        'form-validation-list: No rules found with data-pattern attribute',
+      );
+      return;
+    }
+
+    // Set up ARIA relationship
+    this._setupAccessibility();
+
+    // Only add aria-atomic to list items; live announcements go through the live region
+    this._rules.forEach(({ element }) => {
+      FormValidationListElement.#ensureRulePresentation(element);
+      element.setAttribute('aria-atomic', 'true');
+    });
+
+    // Create the visually-hidden live region outside this described-by container.
+    if (!this._liveRegion) {
+      this._liveRegion = document.createElement('span');
+      this._liveRegion.setAttribute('aria-live', 'polite');
+      this._liveRegion.setAttribute('aria-atomic', 'true');
+      this._liveRegion.className = 'form-validation-list-live-region';
+      const liveRegionHost = this.parentElement || document.body;
+      liveRegionHost.appendChild(this._liveRegion);
+    }
+
+    // Sync icon glyphs and rule state text for this instance
+    this._updateRulePresentation();
+
+    // Attach blur handler to restore aria-describedby
+    if (!this._blurHandler) {
+      this._blurHandler = () => {
+        this._clearPendingBlurRestore();
+        this._pendingBlurRestoreTimeout = setTimeout(() => {
+          this._pendingBlurRestoreTimeout = null;
+          this._restoreDescribedBy();
+        }, FormValidationListElement.#describedByRestoreDelay);
+        if (this._liveRegion) {
+          this._liveRegion.textContent = '';
+        }
+      };
+      this._field.addEventListener('blur', this._blurHandler);
+    }
+
+    // Create validation handler
+    if (!this._validationHandler) {
+      this._validationHandler = () => {
+        this._scheduleValidation();
+      };
+    }
+
+    // Attach event listener
+    this._currentTriggerEvent = this.triggerEvent;
+    this._field.addEventListener(
+      this._currentTriggerEvent,
+      this._validationHandler,
+    );
+
+    // Run initial validation if field has a value
+    if (this._field.value) {
+      this._validateField();
+    }
+  }
+
+  _setupAccessibility() {
+    if (!this._field) return;
+
+    // Ensure this element has an ID
+    const listId = this.id || FormValidationListElement.#generateId();
+    if (!this.id) {
+      this.id = listId;
+    }
+
+    // Add this list to the field's aria-describedby
+    const existingDescribedBy =
+      this._field.getAttribute('aria-describedby');
+    if (existingDescribedBy) {
+      const describedByIds =
+        FormValidationListElement.#parseIdRefs(existingDescribedBy);
+      if (!describedByIds.includes(listId)) {
+        describedByIds.push(listId);
+        this._field.setAttribute(
+          'aria-describedby',
+          describedByIds.join(' '),
+        );
+      }
+    } else {
+      this._field.setAttribute('aria-describedby', listId);
+    }
+  }
+
+  _suspendDescribedBy() {
+    if (this._describedBySuspended || !this._field || !this.id) return;
+    this._removeOwnDescribedBy();
+    this._describedBySuspended = true;
+  }
+
+  _restoreDescribedBy() {
+    this._clearPendingBlurRestore();
+    if (!this._describedBySuspended || !this._field || !this.id) return;
+    const current = this._field.getAttribute('aria-describedby');
+    if (current) {
+      const ids = FormValidationListElement.#parseIdRefs(current);
+      if (!ids.includes(this.id)) {
+        ids.push(this.id);
+        this._field.setAttribute('aria-describedby', ids.join(' '));
+      }
+    } else {
+      this._field.setAttribute('aria-describedby', this.id);
+    }
+    this._describedBySuspended = false;
+  }
+
+  _removeOwnDescribedBy(field = this._field) {
+    if (!field || !this.id) return;
+    const current = field.getAttribute('aria-describedby');
+    if (!current) return;
+    const ids = FormValidationListElement.#parseIdRefs(current).filter(
+      (id) => id !== this.id,
+    );
+    if (ids.length > 0) {
+      field.setAttribute('aria-describedby', ids.join(' '));
+    } else {
+      field.removeAttribute('aria-describedby');
+    }
+  }
+
+  static #parseIdRefs(value) {
+    if (!value) return [];
+    return value.trim().split(/\s+/).filter(Boolean);
+  }
+
+  static #expandCountTemplate(template, matched, total) {
+    return String(template)
+      .replace(/\{matched\}/g, String(matched))
+      .replace(/\{total\}/g, String(total));
+  }
+
+  static #ensureRulePresentation(element) {
+    let iconElement = element.querySelector(
+      ':scope > .form-validation-list-rule-icon',
+    );
+    if (!iconElement) {
+      iconElement = document.createElement('span');
+      iconElement.className = 'form-validation-list-rule-icon';
+      iconElement.setAttribute('aria-hidden', 'true');
+      element.prepend(iconElement);
+    }
+
+    let stateElement = element.querySelector(
+      ':scope > .form-validation-list-rule-state',
+    );
+    if (!stateElement) {
+      stateElement = document.createElement('span');
+      stateElement.className = 'form-validation-list-rule-state';
+      iconElement.insertAdjacentElement('afterend', stateElement);
+    }
+
+    return { iconElement, stateElement };
+  }
+
+  _updateRulePresentation() {
+    if (this.ruleMatchedIcon) {
+      this.style.setProperty(
+        '--form-validation-list-rule-matched-icon',
+        JSON.stringify(this.ruleMatchedIcon),
+      );
+    } else {
+      this.style.removeProperty(
+        '--form-validation-list-rule-matched-icon',
+      );
+    }
+
+    if (this.ruleUnmatchedIcon) {
+      this.style.setProperty(
+        '--form-validation-list-rule-unmatched-icon',
+        JSON.stringify(this.ruleUnmatchedIcon),
+      );
+    } else {
+      this.style.removeProperty(
+        '--form-validation-list-rule-unmatched-icon',
+      );
+    }
+
+    for (let i = 0; i < this._rules.length; i++) {
+      const { element } = this._rules[i];
+      const { stateElement } =
+        FormValidationListElement.#ensureRulePresentation(element);
+      const isMatched = element.classList.contains(this.ruleMatchedClass);
+      stateElement.textContent = this._hasValue
+        ? `${isMatched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
+        : '';
+    }
+  }
+
+  __handleFieldClassChange(oldValue, defaultClass, cacheKey) {
+    const previousClass =
+      oldValue === null ? defaultClass : oldValue || null;
+    this[cacheKey] = null;
+    if (this._field && previousClass) {
+      this._field.classList.remove(previousClass);
+    }
+    if (this._field) {
+      this._validateField();
+    }
+  }
+
+  __handleRuleClassChange(oldValue, defaultClass, cacheKey) {
+    const previousClass =
+      oldValue === null ? defaultClass : oldValue || null;
+    this[cacheKey] = null;
+    if (previousClass) {
+      for (let i = 0; i < this._rules.length; i++) {
+        this._rules[i].element.classList.remove(previousClass);
+      }
+    }
+    if (this._field) {
+      this._validateField();
+    }
+  }
+
+  __rebindValidationHandler(oldValue) {
+    if (!this._field || !this._validationHandler) {
+      return;
+    }
+    this._clearPendingInputThrottle();
+    const previousEvent = this._currentTriggerEvent || oldValue || 'input';
+    const nextEvent = this.triggerEvent;
+    if (previousEvent === nextEvent) {
+      return;
+    }
+    this._field.removeEventListener(previousEvent, this._validationHandler);
+    this._currentTriggerEvent = nextEvent;
+    this._field.addEventListener(nextEvent, this._validationHandler);
+  }
+
+  _clearPendingTimeouts() {
+    if (!this._pendingTimeouts.size) {
+      return;
+    }
+    for (const timeoutId of this._pendingTimeouts) {
+      clearTimeout(timeoutId);
+    }
+    this._pendingTimeouts.clear();
+  }
+
+  _clearPendingInputThrottle() {
+    if (this._pendingInputThrottleTimeout === null) {
+      return;
+    }
+    clearTimeout(this._pendingInputThrottleTimeout);
+    this._pendingInputThrottleTimeout = null;
+  }
+
+  _clearPendingBlurRestore() {
+    if (this._pendingBlurRestoreTimeout === null) {
+      return;
+    }
+    clearTimeout(this._pendingBlurRestoreTimeout);
+    this._pendingBlurRestoreTimeout = null;
+  }
+
+  _scheduleValidation() {
+    if (!this._field) {
+      return;
+    }
+
+    const listenerType = this._currentTriggerEvent || this.triggerEvent;
+    if (listenerType !== 'input') {
+      this._validateField();
+      return;
+    }
+
+    // Cancel pending restore when typing resumes.
+    this._clearPendingBlurRestore();
+
+    // Suspend aria-describedby as soon as the user starts typing
+    this._suspendDescribedBy();
+
+    const throttleDelay = this.inputThrottle;
+    if (throttleDelay <= 0) {
+      this._validateField();
+      return;
+    }
+
+    this._clearPendingInputThrottle();
+    this._pendingInputThrottleTimeout = setTimeout(() => {
+      this._pendingInputThrottleTimeout = null;
+      this._validateField();
+    }, throttleDelay);
+  }
+
+  _validateField() {
+    if (!this._field) return;
+
+    this._clearPendingTimeouts();
+
+    const value = this._field.value;
+    const rulesCount = this._rules.length;
+    let matchedRules = 0;
+    const delay = this.eachDelay;
+
+    // Track whether the field has a value to expose localized rule state text
+    const hasValue = value.length > 0;
+    if (hasValue !== this._hasValue) {
+      this._hasValue = hasValue;
+      this.classList.toggle('has-value', hasValue);
+    }
+
+    // Validate each rule
+    for (let i = 0; i < rulesCount; i++) {
+      const { element, regex } = this._rules[i];
+      const matched = regex.test(value);
+
+      if (matched) {
+        matchedRules++;
+      }
+
+      const applyClasses = () => {
+        this._toggleMatchedClasses(element, matched);
+      };
+
+      // Apply class changes with delay for visual cascade effect
+      if (delay > 0) {
+        const timeoutId = setTimeout(() => {
+          this._pendingTimeouts.delete(timeoutId);
+          applyClasses();
+        }, i * delay);
+        this._pendingTimeouts.add(timeoutId);
+      } else {
+        applyClasses();
+      }
+    }
+
+    // Update field validity
+    const isValid = matchedRules === rulesCount;
+    this._isValid = isValid;
+
+    // Cache class names for performance
+    const validClass = this.fieldValidClass;
+    const invalidClass = this.fieldInvalidClass;
+
+    // Update field classes
+    const fieldClassList = this._field.classList;
+    if (isValid) {
+      fieldClassList.add(validClass);
+      fieldClassList.remove(invalidClass);
+    } else {
+      fieldClassList.add(invalidClass);
+      fieldClassList.remove(validClass);
+    }
+
+    // Update live region with summary announcement
+    if (this._liveRegion) {
+      this._liveRegion.textContent =
+        FormValidationListElement.#expandCountTemplate(
+          this.announcement,
+          matchedRules,
+          rulesCount,
+        );
+    }
+
+    // Integrate with browser validation
+    this._updateFieldValidity(isValid, matchedRules);
+
+    // Fire custom event
+    this.dispatchEvent(
+      new CustomEvent('form-validation-list:validated', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          isValid,
+          matchedRules,
+          totalRules: rulesCount,
+          field: this._field,
+        },
+      }),
+    );
+  }
+
+  _toggleMatchedClasses(element, matched) {
+    const { stateElement } =
+      FormValidationListElement.#ensureRulePresentation(element);
+    const classList = element.classList;
+    if (matched) {
+      classList.add(this.ruleMatchedClass);
+      classList.remove(this.ruleUnmatchedClass);
+    } else {
+      classList.add(this.ruleUnmatchedClass);
+      classList.remove(this.ruleMatchedClass);
+    }
+    stateElement.textContent = this._hasValue
+      ? `${matched ? this.ruleMatchedAlt : this.ruleUnmatchedAlt} `
+      : '';
+  }
+
+  _updateFieldValidity(isValid, matchedRules) {
+    if (!this._field || !this._field.setCustomValidity) return;
+
+    if (isValid) {
+      this._field.setCustomValidity('');
+    } else {
+      const template =
+        this.validationMessage ||
+        'Please match all validation requirements ({matched} of {total})';
+      const message = FormValidationListElement.#expandCountTemplate(
+        template,
+        matchedRules,
+        this._rules.length,
+      );
+      this._field.setCustomValidity(message);
+    }
+  }
+
+  _cleanup() {
+    this._clearPendingBlurRestore();
+    this._clearPendingInputThrottle();
+    this._clearPendingTimeouts();
+
+    // Remove event listeners
+    if (this._field && this._validationHandler) {
+      const listenerType =
+        this._currentTriggerEvent || this.triggerEvent || 'input';
+      this._field.removeEventListener(
+        listenerType,
+        this._validationHandler,
+      );
+    }
+    if (this._field && this._blurHandler) {
+      this._field.removeEventListener('blur', this._blurHandler);
+    }
+
+    // Remove this element from the field's aria-describedby on cleanup
+    this._removeOwnDescribedBy();
+
+    // Clear custom validity
+    if (this._field && this._field.setCustomValidity) {
+      this._field.setCustomValidity('');
+    }
+
+    // Remove classes from field
+    if (this._field) {
+      this._field.classList.remove(
+        this.fieldValidClass,
+        this.fieldInvalidClass,
+      );
+    }
+
+    // Remove classes from rules
+    const rulesCount = this._rules.length;
+    const matchedClass = this.ruleMatchedClass;
+    const unmatchedClass = this.ruleUnmatchedClass;
+
+    for (let i = 0; i < rulesCount; i++) {
+      this._rules[i].element.classList.remove(
+        matchedClass,
+        unmatchedClass,
+      );
+    }
+
+    // Remove live region
+    if (this._liveRegion && this._liveRegion.parentNode) {
+      this._liveRegion.remove();
+    }
+
+    // Remove has-value class
+    this.classList.remove('has-value');
+    this.style.removeProperty('--form-validation-list-rule-matched-icon');
+    this.style.removeProperty('--form-validation-list-rule-unmatched-icon');
+
+    this._field = null;
+    this._rules = [];
+    this._validationHandler = null;
+    this._blurHandler = null;
+    this._liveRegion = null;
+    this._pendingBlurRestoreTimeout = null;
+    this._validClasses = null;
+    this._invalidClasses = null;
+    this._matchedClasses = null;
+    this._unmatchedClasses = null;
+    this._currentTriggerEvent = null;
+    this._describedBySuspended = false;
+    this._hasValue = false;
+    this._isValid = false;
+  }
+
+  /**
+   * Manually trigger validation
+   * @public
+   */
+  validate() {
+    this._validateField();
+    return this._isValid;
+  }
+
+  /**
+   * Get the current validation state
+   * @public
+   * @returns {boolean} Whether all rules are currently matched
+   */
+  get isValid() {
+    return this._isValid;
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@aarongustafson/form-validation-list",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@aarongustafson/form-validation-list",
-			"version": "2.2.0",
+			"version": "2.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@open-wc/eslint-config": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@aarongustafson/form-validation-list",
-	"version": "2.2.0",
+	"version": "2.3.0",
 	"description": "A web component comprising a list of validation rules for a field.",
 	"keywords": [
 		"html",

--- a/test/form-validation-list.test.js
+++ b/test/form-validation-list.test.js
@@ -3,658 +3,664 @@ import { waitFor } from '@testing-library/dom';
 import { FormValidationListElement } from '../form-validation-list.js';
 
 describe('FormValidationListElement', () => {
-	let element;
-	let input;
+  let element;
+  let input;
 
-	beforeEach(() => {
-		// Create a test input field
-		input = document.createElement('input');
-		input.type = 'text';
-		input.id = 'test-input';
-		document.body.appendChild(input);
+  beforeEach(() => {
+    // Create a test input field
+    input = document.createElement('input');
+    input.type = 'text';
+    input.id = 'test-input';
+    document.body.appendChild(input);
 
-		// Create the validation list element
-		element = document.createElement('form-validation-list');
-		element.setAttribute('for', 'test-input');
-		document.body.appendChild(element);
-	});
+    // Create the validation list element
+    element = document.createElement('form-validation-list');
+    element.setAttribute('for', 'test-input');
+    document.body.appendChild(element);
+  });
 
-	afterEach(() => {
-		document.body.innerHTML = '';
-	});
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
-	it('should be defined', () => {
-		expect(customElements.get('form-validation-list')).toBe(
-			FormValidationListElement,
-		);
-	});
+  it('should be defined', () => {
+    expect(customElements.get('form-validation-list')).toBe(
+      FormValidationListElement,
+    );
+  });
 
-	it('should create an instance', () => {
-		expect(element).toBeInstanceOf(FormValidationListElement);
-		expect(element).toBeInstanceOf(HTMLElement);
-	});
+  it('should create an instance', () => {
+    expect(element).toBeInstanceOf(FormValidationListElement);
+    expect(element).toBeInstanceOf(HTMLElement);
+  });
 
-	it('should not have a shadow root (uses light DOM)', () => {
-		expect(element.shadowRoot).toBeFalsy();
-	});
+  it('should not have a shadow root (uses light DOM)', () => {
+    expect(element.shadowRoot).toBeFalsy();
+  });
 
-	it('should not force role="list" on host', () => {
-		expect(element.hasAttribute('role')).toBe(false);
-	});
+  it('should not force role="list" on host', () => {
+    expect(element.hasAttribute('role')).toBe(false);
+  });
 
-	it('should find the associated input field', () => {
-		expect(element._field).toBe(input);
-	});
+  it('should find the associated input field', () => {
+    expect(element._field).toBe(input);
+  });
 
-	it('should set up aria-describedby on the input field', () => {
-		// Need to add rules for the element to set up aria-describedby
-		element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
-		element.disconnectedCallback();
-		element.connectedCallback();
+  it('should set up aria-describedby on the input field', () => {
+    // Need to add rules for the element to set up aria-describedby
+    element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
+    element.disconnectedCallback();
+    element.connectedCallback();
 
-		const describedBy = input.getAttribute('aria-describedby');
-		expect(describedBy).toBeTruthy();
-		expect(describedBy).toContain(element.id);
-	});
+    const listId = element.querySelector('ul, ol').id;
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(describedBy).toContain(listId);
+  });
 
-	it('should preserve existing aria-describedby values', () => {
-		// Clean up previous element
-		element.remove();
+  it('should preserve existing aria-describedby values', () => {
+    // Clean up previous element
+    element.remove();
 
-		// Set existing describedby
-		input.setAttribute('aria-describedby', 'existing-id');
+    // Set existing describedby
+    input.setAttribute('aria-describedby', 'existing-id');
 
-		// Create new element
-		element = document.createElement('form-validation-list');
-		element.setAttribute('for', 'test-input');
-		document.body.appendChild(element);
+    // Create new element
+    element = document.createElement('form-validation-list');
+    element.setAttribute('for', 'test-input');
+    document.body.appendChild(element);
 
-		const describedBy = input.getAttribute('aria-describedby');
-		expect(describedBy).toContain('existing-id');
-		expect(describedBy).toContain(element.id);
-	});
+    element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
+    element.disconnectedCallback();
+    element.connectedCallback();
 
-	describe('property reflection', () => {
-		it('should reflect fieldId property to the for attribute', () => {
-			const otherInput = document.createElement('input');
-			otherInput.id = 'other-input';
-			document.body.appendChild(otherInput);
+    const listId = element.querySelector('ul, ol').id;
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toContain('existing-id');
+    expect(describedBy).toContain(listId);
+  });
 
-			const localElement = document.createElement('form-validation-list');
-			document.body.appendChild(localElement);
+  describe('property reflection', () => {
+    it('should reflect fieldId property to the for attribute', () => {
+      const otherInput = document.createElement('input');
+      otherInput.id = 'other-input';
+      document.body.appendChild(otherInput);
 
-			localElement.fieldId = 'other-input';
-			expect(localElement.getAttribute('for')).toBe('other-input');
-		});
+      const localElement = document.createElement('form-validation-list');
+      document.body.appendChild(localElement);
 
-		it('should reflect triggerEvent property to the attribute', () => {
-			const localElement = document.createElement('form-validation-list');
-			localElement.triggerEvent = 'blur';
-			expect(localElement.getAttribute('trigger-event')).toBe('blur');
-		});
+      localElement.fieldId = 'other-input';
+      expect(localElement.getAttribute('for')).toBe('other-input');
+    });
 
-		it('should normalize unsupported trigger events to input', () => {
-			const localElement = document.createElement('form-validation-list');
-			localElement.triggerEvent = 'change';
-			expect(localElement.getAttribute('trigger-event')).toBe('input');
-			expect(localElement.triggerEvent).toBe('input');
-		});
+    it('should reflect triggerEvent property to the attribute', () => {
+      const localElement = document.createElement('form-validation-list');
+      localElement.triggerEvent = 'blur';
+      expect(localElement.getAttribute('trigger-event')).toBe('blur');
+    });
 
-		it('should upgrade properties set before connecting', async () => {
-			const upgradeInput = document.createElement('input');
-			upgradeInput.id = 'upgrade-input';
-			document.body.appendChild(upgradeInput);
+    it('should normalize unsupported trigger events to input', () => {
+      const localElement = document.createElement('form-validation-list');
+      localElement.triggerEvent = 'change';
+      expect(localElement.getAttribute('trigger-event')).toBe('input');
+      expect(localElement.triggerEvent).toBe('input');
+    });
 
-			const localElement = document.createElement('form-validation-list');
-			localElement.fieldId = 'upgrade-input';
-			localElement.triggerEvent = 'blur';
-			localElement.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-			localElement.setAttribute('each-delay', '0');
-			document.body.appendChild(localElement);
+    it('should upgrade properties set before connecting', async () => {
+      const upgradeInput = document.createElement('input');
+      upgradeInput.id = 'upgrade-input';
+      document.body.appendChild(upgradeInput);
 
-			upgradeInput.value = 'TEST';
-			upgradeInput.dispatchEvent(new Event('blur'));
+      const localElement = document.createElement('form-validation-list');
+      localElement.fieldId = 'upgrade-input';
+      localElement.triggerEvent = 'blur';
+      localElement.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+      localElement.setAttribute('each-delay', '0');
+      document.body.appendChild(localElement);
 
-			await waitFor(() => {
-				expect(
-					localElement
-						.querySelector('[data-pattern]')
-						.classList.contains('validation-matched'),
-				).toBe(true);
-			});
-		});
-	});
+      upgradeInput.value = 'TEST';
+      upgradeInput.dispatchEvent(new Event('blur'));
 
-	describe('validation rules', () => {
-		beforeEach(() => {
-			element.innerHTML = `
+      await waitFor(() => {
+        expect(
+          localElement
+            .querySelector('[data-pattern]')
+            .classList.contains('validation-matched'),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe('validation rules', () => {
+    beforeEach(() => {
+      element.innerHTML = `
 				<ul>
 					<li data-pattern="[A-Z]+">At least one capital letter</li>
 					<li data-pattern="[a-z]+">At least one lowercase letter</li>
 					<li data-pattern="[0-9]+">At least one number</li>
 				</ul>
 			`;
-			element.setAttribute('each-delay', '0');
-
-			// Trigger connectedCallback again to pick up new rules
-			element.disconnectedCallback();
-			element.connectedCallback();
-		});
-
-		it('should find all validation rules', () => {
-			expect(element._rules.length).toBe(3);
-		});
-
-		it('should not force role="listitem" on rule elements', () => {
-			const rules = element.querySelectorAll('[data-pattern]');
-			rules.forEach((rule) => {
-				expect(rule.hasAttribute('role')).toBe(false);
-			});
-		});
-
-		it('should set aria-atomic on rule elements (not aria-live)', () => {
-			const rules = element.querySelectorAll('[data-pattern]');
-			rules.forEach((rule) => {
-				expect(rule.getAttribute('aria-atomic')).toBe('true');
-				expect(rule.hasAttribute('aria-live')).toBe(false);
-			});
-		});
-
-		it('should validate input value against rules', async () => {
-			input.value = 'Test123';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				const rules = element.querySelectorAll('[data-pattern]');
-				expect(rules[0].classList.contains('validation-matched')).toBe(
-					true,
-				);
-				expect(rules[1].classList.contains('validation-matched')).toBe(
-					true,
-				);
-				expect(rules[2].classList.contains('validation-matched')).toBe(
-					true,
-				);
-			});
-		});
-
-		it('should mark unmatched rules', async () => {
-			input.value = 'test'; // Only lowercase
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				const rules = element.querySelectorAll('[data-pattern]');
-				expect(
-					rules[0].classList.contains('validation-unmatched'),
-				).toBe(true);
-				expect(rules[1].classList.contains('validation-matched')).toBe(
-					true,
-				);
-				expect(
-					rules[2].classList.contains('validation-unmatched'),
-				).toBe(true);
-			});
-		});
-
-		it('should add validation classes to the input field', async () => {
-			input.value = 'Test123';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(input.classList.contains('validation-valid')).toBe(true);
-				expect(input.classList.contains('validation-invalid')).toBe(
-					false,
-				);
-			});
-		});
-
-		it('should update field custom validity', async () => {
-			input.value = 'test'; // Invalid
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(input.validationMessage).toBeTruthy();
-			});
-
-			input.value = 'Test123'; // Valid
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(input.validationMessage).toBe('');
-			});
-		});
-
-		it('should replace all placeholders in validation-message template', async () => {
-			element.setAttribute(
-				'validation-message',
-				'Matched {matched}/{matched} of {total}/{total}',
-			);
-			element.setAttribute('each-delay', '0');
-			element.setAttribute('input-throttle', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			input.value = 'test';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(input.validationMessage).toBe('Matched 1/1 of 3/3');
-			});
-		});
-
-		it('should fire validation event', () => {
-			return new Promise((resolve) => {
-				element.addEventListener(
-					'form-validation-list:validated',
-					(e) => {
-						expect(e.detail.isValid).toBeDefined();
-						expect(e.detail.matchedRules).toBeDefined();
-						expect(e.detail.totalRules).toBe(3);
-						expect(e.detail.field).toBe(input);
-						resolve();
-					},
-				);
-
-				input.value = 'Test123';
-				input.dispatchEvent(new Event('input'));
-			});
-		});
-
-		it('should create a live region with aria-live and aria-atomic', () => {
-			const liveRegion = document.querySelector(
-				'.form-validation-list-live-region',
-			);
-			expect(liveRegion).toBeTruthy();
-			expect(liveRegion.getAttribute('aria-live')).toBe('polite');
-			expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
-		});
-
-		it('should update the live region with the announcement after validation', async () => {
-			element.setAttribute('each-delay', '0');
-			element.setAttribute('input-throttle', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			input.value = 'Test123';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				const liveRegion = document.querySelector(
-					'.form-validation-list-live-region',
-				);
-				expect(liveRegion.textContent).toContain('3');
-			});
-		});
-
-		it('should replace all matched and total placeholders in announcement', async () => {
-			element.setAttribute(
-				'announcement',
-				'Matched {matched}/{matched} of {total}/{total}',
-			);
-			element.setAttribute('each-delay', '0');
-			element.setAttribute('input-throttle', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			input.value = 'Test123';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				const liveRegion = document.querySelector(
-					'.form-validation-list-live-region',
-				);
-				expect(liveRegion.textContent).toBe('Matched 3/3 of 3/3');
-			});
-		});
-
-		it('should suspend aria-describedby on input and restore on blur', () => {
-			vi.useFakeTimers();
-
-			try {
-				element.setAttribute('each-delay', '0');
-				element.setAttribute('input-throttle', '0');
-				element.disconnectedCallback();
-				element.connectedCallback();
-
-				const listId = element.id;
-				expect(input.getAttribute('aria-describedby')).toContain(
-					listId,
-				);
-
-				input.value = 'A';
-				input.dispatchEvent(new Event('input'));
-				const describedByDuringTyping =
-					input.getAttribute('aria-describedby');
-				expect(
-					describedByDuringTyping === null ||
-						!describedByDuringTyping.includes(listId),
-				).toBe(true);
-
-				input.dispatchEvent(new Event('blur'));
-				const describedByAfterBlur =
-					input.getAttribute('aria-describedby');
-				expect(
-					describedByAfterBlur === null ||
-						!describedByAfterBlur.includes(listId),
-				).toBe(true);
-
-				vi.advanceTimersByTime(200);
-				expect(input.getAttribute('aria-describedby')).toContain(
-					listId,
-				);
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-
-		it('should toggle has-value class based on field content', async () => {
-			element.setAttribute('each-delay', '0');
-			element.setAttribute('input-throttle', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			expect(element.classList.contains('has-value')).toBe(false);
-
-			input.value = 'A';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(element.classList.contains('has-value')).toBe(true);
-			});
-
-			input.value = '';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(element.classList.contains('has-value')).toBe(false);
-			});
-		});
-	});
-
-	describe('configuration attributes', () => {
-		it('should use default trigger event', () => {
-			expect(element.triggerEvent).toBe('input');
-		});
-
-		it('should allow custom trigger event', () => {
-			element.setAttribute('trigger-event', 'blur');
-			expect(element.triggerEvent).toBe('blur');
-		});
-
-		it('should use default each-delay', () => {
-			expect(element.eachDelay).toBe(150);
-		});
-
-		it('should use default input-throttle', () => {
-			expect(element.inputThrottle).toBe(250);
-		});
-
-		it('should allow custom input-throttle', () => {
-			element.setAttribute('input-throttle', '40');
-			expect(element.inputThrottle).toBe(40);
-		});
-
-		it('should allow custom each-delay', () => {
-			element.setAttribute('each-delay', '200');
-			expect(element.eachDelay).toBe(200);
-		});
-
-		it('should use default class names', () => {
-			expect(element.fieldInvalidClass).toBe('validation-invalid');
-			expect(element.fieldValidClass).toBe('validation-valid');
-			expect(element.ruleUnmatchedClass).toBe('validation-unmatched');
-			expect(element.ruleMatchedClass).toBe('validation-matched');
-		});
-
-		it('should use default icon alt text', () => {
-			expect(element.ruleMatchedAlt).toBe('Criteria met');
-			expect(element.ruleUnmatchedAlt).toBe('Criteria not met');
-		});
-
-		it('should allow custom icon alt text', () => {
-			element.setAttribute('rule-matched-alt', 'Met');
-			element.setAttribute('rule-unmatched-alt', 'Not met');
-			expect(element.ruleMatchedAlt).toBe('Met');
-			expect(element.ruleUnmatchedAlt).toBe('Not met');
-		});
-
-		it('should use default announcement template', () => {
-			expect(element.announcement).toBe(
-				'Criteria met: {matched} of {total}',
-			);
-		});
-
-		it('should allow custom announcement template', () => {
-			element.setAttribute('announcement', '{matched}/{total} ok');
-			expect(element.announcement).toBe('{matched}/{total} ok');
-		});
-
-		it('should allow custom icons via attribute', () => {
-			element.setAttribute('rule-matched-icon', '✅');
-			element.setAttribute('rule-unmatched-icon', '❌');
-			expect(element.ruleMatchedIcon).toBe('✅');
-			expect(element.ruleUnmatchedIcon).toBe('❌');
-		});
-
-		it('should allow custom class names', () => {
-			element.setAttribute('field-invalid-class', 'custom-invalid');
-			element.setAttribute('field-valid-class', 'custom-valid');
-			element.setAttribute('rule-unmatched-class', 'custom-unmatched');
-			element.setAttribute('rule-matched-class', 'custom-matched');
-
-			expect(element.fieldInvalidClass).toBe('custom-invalid');
-			expect(element.fieldValidClass).toBe('custom-valid');
-			expect(element.ruleUnmatchedClass).toBe('custom-unmatched');
-			expect(element.ruleMatchedClass).toBe('custom-matched');
-		});
-
-		it('should rebind validation handler when trigger-event changes', async () => {
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-			element.setAttribute('each-delay', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			element.setAttribute('trigger-event', 'blur');
-			input.value = 'TEST';
-			input.dispatchEvent(new Event('blur'));
-
-			await waitFor(() => {
-				expect(
-					element
-						.querySelector('[data-pattern]')
-						.classList.contains('validation-matched'),
-				).toBe(true);
-			});
-		});
-
-		it('should refresh field classes when field-valid-class changes', async () => {
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-			element.setAttribute('each-delay', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			input.value = 'TEST';
-			input.dispatchEvent(new Event('input'));
-			await waitFor(() => {
-				expect(input.classList.contains('validation-valid')).toBe(true);
-			});
-
-			element.setAttribute('field-valid-class', 'custom-good');
-			await waitFor(() => {
-				expect(input.classList.contains('custom-good')).toBe(true);
-				expect(input.classList.contains('validation-valid')).toBe(
-					false,
-				);
-			});
-		});
-
-		it('should refresh rule classes when rule-matched-class changes', async () => {
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-			element.setAttribute('each-delay', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			input.value = 'TEST';
-			input.dispatchEvent(new Event('input'));
-			await waitFor(() => {
-				expect(
-					element
-						.querySelector('[data-pattern]')
-						.classList.contains('validation-matched'),
-				).toBe(true);
-			});
-
-			element.setAttribute('rule-matched-class', 'custom-match');
-			await waitFor(() => {
-				const rule = element.querySelector('[data-pattern]');
-				expect(rule.classList.contains('custom-match')).toBe(true);
-				expect(rule.classList.contains('validation-matched')).toBe(
-					false,
-				);
-			});
-		});
-
-		it('should throttle input-triggered validation and use latest value', () => {
-			vi.useFakeTimers();
-
-			try {
-				element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-				element.setAttribute('each-delay', '0');
-				element.setAttribute('input-throttle', '100');
-				element.disconnectedCallback();
-				element.connectedCallback();
-
-				const rule = element.querySelector('[data-pattern]');
-
-				input.value = 'abc';
-				input.dispatchEvent(new Event('input'));
-
-				input.value = 'ABC';
-				input.dispatchEvent(new Event('input'));
-
-				expect(rule.classList.contains('validation-matched')).toBe(
-					false,
-				);
-				expect(rule.classList.contains('validation-unmatched')).toBe(
-					false,
-				);
-
-				vi.advanceTimersByTime(100);
-
-				expect(rule.classList.contains('validation-matched')).toBe(
-					true,
-				);
-				expect(rule.classList.contains('validation-unmatched')).toBe(
-					false,
-				);
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-
-		it('should not throttle blur trigger events', () => {
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-			element.setAttribute('trigger-event', 'blur');
-			element.setAttribute('input-throttle', '1000');
-			element.setAttribute('each-delay', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			const rule = element.querySelector('[data-pattern]');
-			input.value = 'ABC';
-			input.dispatchEvent(new Event('blur'));
-
-			expect(rule.classList.contains('validation-matched')).toBe(true);
-			expect(rule.classList.contains('validation-unmatched')).toBe(false);
-		});
-	});
-
-	describe('public API', () => {
-		beforeEach(() => {
-			element.innerHTML = `
+      element.setAttribute('each-delay', '0');
+
+      // Trigger connectedCallback again to pick up new rules
+      element.disconnectedCallback();
+      element.connectedCallback();
+    });
+
+    it('should find all validation rules', () => {
+      expect(element._rules.length).toBe(3);
+    });
+
+    it('should not force role="listitem" on rule elements', () => {
+      const rules = element.querySelectorAll('[data-pattern]');
+      rules.forEach((rule) => {
+        expect(rule.hasAttribute('role')).toBe(false);
+      });
+    });
+
+    it('should set aria-atomic on rule elements (not aria-live)', () => {
+      const rules = element.querySelectorAll('[data-pattern]');
+      rules.forEach((rule) => {
+        expect(rule.getAttribute('aria-atomic')).toBe('true');
+        expect(rule.hasAttribute('aria-live')).toBe(false);
+      });
+    });
+
+    it('should validate input value against rules', async () => {
+      input.value = 'Test123';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        const rules = element.querySelectorAll('[data-pattern]');
+        expect(rules[0].classList.contains('validation-matched')).toBe(
+          true,
+        );
+        expect(rules[1].classList.contains('validation-matched')).toBe(
+          true,
+        );
+        expect(rules[2].classList.contains('validation-matched')).toBe(
+          true,
+        );
+      });
+    });
+
+    it('should mark unmatched rules', async () => {
+      input.value = 'test'; // Only lowercase
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        const rules = element.querySelectorAll('[data-pattern]');
+        expect(
+          rules[0].classList.contains('validation-unmatched'),
+        ).toBe(true);
+        expect(rules[1].classList.contains('validation-matched')).toBe(
+          true,
+        );
+        expect(
+          rules[2].classList.contains('validation-unmatched'),
+        ).toBe(true);
+      });
+    });
+
+    it('should add validation classes to the input field', async () => {
+      input.value = 'Test123';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(input.classList.contains('validation-valid')).toBe(true);
+        expect(input.classList.contains('validation-invalid')).toBe(
+          false,
+        );
+      });
+    });
+
+    it('should update field custom validity', async () => {
+      input.value = 'test'; // Invalid
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(input.validationMessage).toBeTruthy();
+      });
+
+      input.value = 'Test123'; // Valid
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(input.validationMessage).toBe('');
+      });
+    });
+
+    it('should replace all placeholders in validation-message template', async () => {
+      element.setAttribute(
+        'validation-message',
+        'Matched {matched}/{matched} of {total}/{total}',
+      );
+      element.setAttribute('each-delay', '0');
+      element.setAttribute('input-throttle', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      input.value = 'test';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(input.validationMessage).toBe('Matched 1/1 of 3/3');
+      });
+    });
+
+    it('should fire validation event', () => {
+      return new Promise((resolve) => {
+        element.addEventListener(
+          'form-validation-list:validated',
+          (e) => {
+            expect(e.detail.isValid).toBeDefined();
+            expect(e.detail.matchedRules).toBeDefined();
+            expect(e.detail.totalRules).toBe(3);
+            expect(e.detail.field).toBe(input);
+            resolve();
+          },
+        );
+
+        input.value = 'Test123';
+        input.dispatchEvent(new Event('input'));
+      });
+    });
+
+    it('should create a live region with aria-live and aria-atomic', () => {
+      const liveRegion = document.querySelector(
+        '.form-validation-list-live-region',
+      );
+      expect(liveRegion).toBeTruthy();
+      expect(liveRegion.getAttribute('aria-live')).toBe('polite');
+      expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
+    });
+
+    it('should update the live region with the announcement after validation', async () => {
+      element.setAttribute('each-delay', '0');
+      element.setAttribute('input-throttle', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      input.value = 'Test123';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        const liveRegion = document.querySelector(
+          '.form-validation-list-live-region',
+        );
+        expect(liveRegion.textContent).toContain('3');
+      });
+    });
+
+    it('should replace all matched and total placeholders in announcement', async () => {
+      element.setAttribute(
+        'announcement',
+        'Matched {matched}/{matched} of {total}/{total}',
+      );
+      element.setAttribute('each-delay', '0');
+      element.setAttribute('input-throttle', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      input.value = 'Test123';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        const liveRegion = document.querySelector(
+          '.form-validation-list-live-region',
+        );
+        expect(liveRegion.textContent).toBe('Matched 3/3 of 3/3');
+      });
+    });
+
+    it('should suspend aria-describedby on input and restore on blur', () => {
+      vi.useFakeTimers();
+
+      try {
+        element.setAttribute('each-delay', '0');
+        element.setAttribute('input-throttle', '0');
+        element.disconnectedCallback();
+        element.connectedCallback();
+
+        const listId = element.querySelector('ul, ol').id;
+        expect(input.getAttribute('aria-describedby')).toContain(
+          listId,
+        );
+
+        input.value = 'A';
+        input.dispatchEvent(new Event('input'));
+        const describedByDuringTyping =
+          input.getAttribute('aria-describedby');
+        expect(
+          describedByDuringTyping === null ||
+          !describedByDuringTyping.includes(listId),
+        ).toBe(true);
+
+        input.dispatchEvent(new Event('blur'));
+        const describedByAfterBlur =
+          input.getAttribute('aria-describedby');
+        expect(
+          describedByAfterBlur === null ||
+          !describedByAfterBlur.includes(listId),
+        ).toBe(true);
+
+        vi.advanceTimersByTime(200);
+        expect(input.getAttribute('aria-describedby')).toContain(
+          listId,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should toggle has-value class based on field content', async () => {
+      element.setAttribute('each-delay', '0');
+      element.setAttribute('input-throttle', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      expect(element.classList.contains('has-value')).toBe(false);
+
+      input.value = 'A';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(element.classList.contains('has-value')).toBe(true);
+      });
+
+      input.value = '';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(element.classList.contains('has-value')).toBe(false);
+      });
+    });
+  });
+
+  describe('configuration attributes', () => {
+    it('should use default trigger event', () => {
+      expect(element.triggerEvent).toBe('input');
+    });
+
+    it('should allow custom trigger event', () => {
+      element.setAttribute('trigger-event', 'blur');
+      expect(element.triggerEvent).toBe('blur');
+    });
+
+    it('should use default each-delay', () => {
+      expect(element.eachDelay).toBe(150);
+    });
+
+    it('should use default input-throttle', () => {
+      expect(element.inputThrottle).toBe(250);
+    });
+
+    it('should allow custom input-throttle', () => {
+      element.setAttribute('input-throttle', '40');
+      expect(element.inputThrottle).toBe(40);
+    });
+
+    it('should allow custom each-delay', () => {
+      element.setAttribute('each-delay', '200');
+      expect(element.eachDelay).toBe(200);
+    });
+
+    it('should use default class names', () => {
+      expect(element.fieldInvalidClass).toBe('validation-invalid');
+      expect(element.fieldValidClass).toBe('validation-valid');
+      expect(element.ruleUnmatchedClass).toBe('validation-unmatched');
+      expect(element.ruleMatchedClass).toBe('validation-matched');
+    });
+
+    it('should use default icon alt text', () => {
+      expect(element.ruleMatchedAlt).toBe('Criteria met');
+      expect(element.ruleUnmatchedAlt).toBe('Criteria not met');
+    });
+
+    it('should allow custom icon alt text', () => {
+      element.setAttribute('rule-matched-alt', 'Met');
+      element.setAttribute('rule-unmatched-alt', 'Not met');
+      expect(element.ruleMatchedAlt).toBe('Met');
+      expect(element.ruleUnmatchedAlt).toBe('Not met');
+    });
+
+    it('should use default announcement template', () => {
+      expect(element.announcement).toBe(
+        'Criteria met: {matched} of {total}',
+      );
+    });
+
+    it('should allow custom announcement template', () => {
+      element.setAttribute('announcement', '{matched}/{total} ok');
+      expect(element.announcement).toBe('{matched}/{total} ok');
+    });
+
+    it('should allow custom icons via attribute', () => {
+      element.setAttribute('rule-matched-icon', '✅');
+      element.setAttribute('rule-unmatched-icon', '❌');
+      expect(element.ruleMatchedIcon).toBe('✅');
+      expect(element.ruleUnmatchedIcon).toBe('❌');
+    });
+
+    it('should allow custom class names', () => {
+      element.setAttribute('field-invalid-class', 'custom-invalid');
+      element.setAttribute('field-valid-class', 'custom-valid');
+      element.setAttribute('rule-unmatched-class', 'custom-unmatched');
+      element.setAttribute('rule-matched-class', 'custom-matched');
+
+      expect(element.fieldInvalidClass).toBe('custom-invalid');
+      expect(element.fieldValidClass).toBe('custom-valid');
+      expect(element.ruleUnmatchedClass).toBe('custom-unmatched');
+      expect(element.ruleMatchedClass).toBe('custom-matched');
+    });
+
+    it('should rebind validation handler when trigger-event changes', async () => {
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+      element.setAttribute('each-delay', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      element.setAttribute('trigger-event', 'blur');
+      input.value = 'TEST';
+      input.dispatchEvent(new Event('blur'));
+
+      await waitFor(() => {
+        expect(
+          element
+            .querySelector('[data-pattern]')
+            .classList.contains('validation-matched'),
+        ).toBe(true);
+      });
+    });
+
+    it('should refresh field classes when field-valid-class changes', async () => {
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+      element.setAttribute('each-delay', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      input.value = 'TEST';
+      input.dispatchEvent(new Event('input'));
+      await waitFor(() => {
+        expect(input.classList.contains('validation-valid')).toBe(true);
+      });
+
+      element.setAttribute('field-valid-class', 'custom-good');
+      await waitFor(() => {
+        expect(input.classList.contains('custom-good')).toBe(true);
+        expect(input.classList.contains('validation-valid')).toBe(
+          false,
+        );
+      });
+    });
+
+    it('should refresh rule classes when rule-matched-class changes', async () => {
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+      element.setAttribute('each-delay', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      input.value = 'TEST';
+      input.dispatchEvent(new Event('input'));
+      await waitFor(() => {
+        expect(
+          element
+            .querySelector('[data-pattern]')
+            .classList.contains('validation-matched'),
+        ).toBe(true);
+      });
+
+      element.setAttribute('rule-matched-class', 'custom-match');
+      await waitFor(() => {
+        const rule = element.querySelector('[data-pattern]');
+        expect(rule.classList.contains('custom-match')).toBe(true);
+        expect(rule.classList.contains('validation-matched')).toBe(
+          false,
+        );
+      });
+    });
+
+    it('should throttle input-triggered validation and use latest value', () => {
+      vi.useFakeTimers();
+
+      try {
+        element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+        element.setAttribute('each-delay', '0');
+        element.setAttribute('input-throttle', '100');
+        element.disconnectedCallback();
+        element.connectedCallback();
+
+        const rule = element.querySelector('[data-pattern]');
+
+        input.value = 'abc';
+        input.dispatchEvent(new Event('input'));
+
+        input.value = 'ABC';
+        input.dispatchEvent(new Event('input'));
+
+        expect(rule.classList.contains('validation-matched')).toBe(
+          false,
+        );
+        expect(rule.classList.contains('validation-unmatched')).toBe(
+          false,
+        );
+
+        vi.advanceTimersByTime(100);
+
+        expect(rule.classList.contains('validation-matched')).toBe(
+          true,
+        );
+        expect(rule.classList.contains('validation-unmatched')).toBe(
+          false,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should not throttle blur trigger events', () => {
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+      element.setAttribute('trigger-event', 'blur');
+      element.setAttribute('input-throttle', '1000');
+      element.setAttribute('each-delay', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      const rule = element.querySelector('[data-pattern]');
+      input.value = 'ABC';
+      input.dispatchEvent(new Event('blur'));
+
+      expect(rule.classList.contains('validation-matched')).toBe(true);
+      expect(rule.classList.contains('validation-unmatched')).toBe(false);
+    });
+  });
+
+  describe('public API', () => {
+    beforeEach(() => {
+      element.innerHTML = `
 				<ul>
 					<li data-pattern="[A-Z]+">Capital letter</li>
 					<li data-pattern="[0-9]+">Number</li>
 				</ul>
 			`;
-			element.disconnectedCallback();
-			element.connectedCallback();
-		});
+      element.disconnectedCallback();
+      element.connectedCallback();
+    });
 
-		it('should provide validate() method', () => {
-			expect(typeof element.validate).toBe('function');
-		});
+    it('should provide validate() method', () => {
+      expect(typeof element.validate).toBe('function');
+    });
 
-		it('validate() should return validation state', () => {
-			input.value = 'Test123';
-			const isValid = element.validate();
-			expect(typeof isValid).toBe('boolean');
-		});
+    it('validate() should return validation state', () => {
+      input.value = 'Test123';
+      const isValid = element.validate();
+      expect(typeof isValid).toBe('boolean');
+    });
 
-		it('should provide isValid getter', () => {
-			input.value = 'Test123';
-			element.validate();
-			expect(typeof element.isValid).toBe('boolean');
-		});
-	});
+    it('should provide isValid getter', () => {
+      input.value = 'Test123';
+      element.validate();
+      expect(typeof element.isValid).toBe('boolean');
+    });
+  });
 
-	describe('cleanup', () => {
-		it('should remove only this id from aria-describedby when disconnected', () => {
-			input.setAttribute('aria-describedby', 'existing-id');
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-			element.disconnectedCallback();
-			element.connectedCallback();
+  describe('cleanup', () => {
+    it('should remove only this id from aria-describedby when disconnected', () => {
+      input.setAttribute('aria-describedby', 'existing-id');
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+      element.disconnectedCallback();
+      element.connectedCallback();
 
-			const listId = element.id;
-			expect(input.getAttribute('aria-describedby')).toContain(
-				'existing-id',
-			);
-			expect(input.getAttribute('aria-describedby')).toContain(listId);
+      const listId = element.querySelector('ul, ol').id;
+      expect(input.getAttribute('aria-describedby')).toContain(
+        'existing-id',
+      );
+      expect(input.getAttribute('aria-describedby')).toContain(listId);
 
-			element.disconnectedCallback();
+      element.disconnectedCallback();
 
-			expect(input.getAttribute('aria-describedby')).toBe('existing-id');
-		});
+      expect(input.getAttribute('aria-describedby')).toBe('existing-id');
+    });
 
-		it('should cleanup when disconnected', async () => {
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-			element.setAttribute('each-delay', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
+    it('should cleanup when disconnected', async () => {
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+      element.setAttribute('each-delay', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
 
-			input.value = 'Test';
-			input.dispatchEvent(new Event('input'));
-			await waitFor(() => {
-				expect(input.classList.contains('validation-valid')).toBe(true);
-			});
+      input.value = 'Test';
+      input.dispatchEvent(new Event('input'));
+      await waitFor(() => {
+        expect(input.classList.contains('validation-valid')).toBe(true);
+      });
 
-			element.disconnectedCallback();
+      element.disconnectedCallback();
 
-			// Field should not have validation classes after cleanup
-			expect(input.classList.contains('validation-valid')).toBe(false);
-			expect(input.classList.contains('validation-invalid')).toBe(false);
-		});
+      // Field should not have validation classes after cleanup
+      expect(input.classList.contains('validation-valid')).toBe(false);
+      expect(input.classList.contains('validation-invalid')).toBe(false);
+    });
 
-		it('should cleanup when for attribute changes', () => {
-			const nextInput = document.createElement('input');
-			nextInput.type = 'text';
-			nextInput.id = 'next-input';
-			document.body.appendChild(nextInput);
+    it('should cleanup when for attribute changes', () => {
+      const nextInput = document.createElement('input');
+      nextInput.type = 'text';
+      nextInput.id = 'next-input';
+      document.body.appendChild(nextInput);
 
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-			element.disconnectedCallback();
-			element.connectedCallback();
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+      element.disconnectedCallback();
+      element.connectedCallback();
 
-			const oldField = element._field;
-			oldField.setAttribute('aria-describedby', 'existing-id');
-			element._setupAccessibility();
+      const oldField = element._field;
+      oldField.setAttribute('aria-describedby', 'existing-id');
+      element._setupAccessibility();
 
-			element.setAttribute('for', 'next-input');
+      element.setAttribute('for', 'next-input');
 
-			expect(element._field).not.toBe(oldField);
-			expect(oldField.getAttribute('aria-describedby')).toBe(
-				'existing-id',
-			);
-		});
-	});
+      expect(element._field).not.toBe(oldField);
+      expect(oldField.getAttribute('aria-describedby')).toBe(
+        'existing-id',
+      );
+    });
+  });
 });

--- a/test/form-validation-list.test.js
+++ b/test/form-validation-list.test.js
@@ -38,8 +38,8 @@ describe('FormValidationListElement', () => {
 		expect(element.shadowRoot).toBeFalsy();
 	});
 
-	it('should have role="list"', () => {
-		expect(element.getAttribute('role')).toBe('list');
+	it('should not force role="list" on host', () => {
+		expect(element.hasAttribute('role')).toBe(false);
 	});
 
 	it('should find the associated input field', () => {
@@ -138,10 +138,10 @@ describe('FormValidationListElement', () => {
 			expect(element._rules.length).toBe(3);
 		});
 
-		it('should set role="listitem" on rule elements', () => {
+		it('should not force role="listitem" on rule elements', () => {
 			const rules = element.querySelectorAll('[data-pattern]');
 			rules.forEach((rule) => {
-				expect(rule.getAttribute('role')).toBe('listitem');
+				expect(rule.hasAttribute('role')).toBe(false);
 			});
 		});
 

--- a/test/form-validation-list.test.js
+++ b/test/form-validation-list.test.js
@@ -3,658 +3,658 @@ import { waitFor } from '@testing-library/dom';
 import { FormValidationListElement } from '../form-validation-list.js';
 
 describe('FormValidationListElement', () => {
-  let element;
-  let input;
+	let element;
+	let input;
 
-  beforeEach(() => {
-    // Create a test input field
-    input = document.createElement('input');
-    input.type = 'text';
-    input.id = 'test-input';
-    document.body.appendChild(input);
+	beforeEach(() => {
+		// Create a test input field
+		input = document.createElement('input');
+		input.type = 'text';
+		input.id = 'test-input';
+		document.body.appendChild(input);
 
-    // Create the validation list element
-    element = document.createElement('form-validation-list');
-    element.setAttribute('for', 'test-input');
-    document.body.appendChild(element);
-  });
+		// Create the validation list element
+		element = document.createElement('form-validation-list');
+		element.setAttribute('for', 'test-input');
+		document.body.appendChild(element);
+	});
 
-  afterEach(() => {
-    document.body.innerHTML = '';
-  });
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
 
-  it('should be defined', () => {
-    expect(customElements.get('form-validation-list')).toBe(
-      FormValidationListElement,
-    );
-  });
+	it('should be defined', () => {
+		expect(customElements.get('form-validation-list')).toBe(
+			FormValidationListElement,
+		);
+	});
 
-  it('should create an instance', () => {
-    expect(element).toBeInstanceOf(FormValidationListElement);
-    expect(element).toBeInstanceOf(HTMLElement);
-  });
+	it('should create an instance', () => {
+		expect(element).toBeInstanceOf(FormValidationListElement);
+		expect(element).toBeInstanceOf(HTMLElement);
+	});
 
-  it('should not have a shadow root (uses light DOM)', () => {
-    expect(element.shadowRoot).toBeFalsy();
-  });
+	it('should not have a shadow root (uses light DOM)', () => {
+		expect(element.shadowRoot).toBeFalsy();
+	});
 
-  it('should not force role="list" on host', () => {
-    expect(element.hasAttribute('role')).toBe(false);
-  });
+	it('should not force role="list" on host', () => {
+		expect(element.hasAttribute('role')).toBe(false);
+	});
 
-  it('should find the associated input field', () => {
-    expect(element._field).toBe(input);
-  });
+	it('should find the associated input field', () => {
+		expect(element._field).toBe(input);
+	});
 
-  it('should set up aria-describedby on the input field', () => {
-    // Need to add rules for the element to set up aria-describedby
-    element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
-    element.disconnectedCallback();
-    element.connectedCallback();
+	it('should set up aria-describedby on the input field', () => {
+		// Need to add rules for the element to set up aria-describedby
+		element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
+		element.disconnectedCallback();
+		element.connectedCallback();
 
-    const describedBy = input.getAttribute('aria-describedby');
-    expect(describedBy).toBeTruthy();
-    expect(describedBy).toContain(element.id);
-  });
+		const describedBy = input.getAttribute('aria-describedby');
+		expect(describedBy).toBeTruthy();
+		expect(describedBy).toContain(element.id);
+	});
 
-  it('should preserve existing aria-describedby values', () => {
-    // Clean up previous element
-    element.remove();
+	it('should preserve existing aria-describedby values', () => {
+		// Clean up previous element
+		element.remove();
 
-    // Set existing describedby
-    input.setAttribute('aria-describedby', 'existing-id');
+		// Set existing describedby
+		input.setAttribute('aria-describedby', 'existing-id');
 
-    // Create new element
-    element = document.createElement('form-validation-list');
-    element.setAttribute('for', 'test-input');
-    document.body.appendChild(element);
+		// Create new element
+		element = document.createElement('form-validation-list');
+		element.setAttribute('for', 'test-input');
+		document.body.appendChild(element);
 
-    const describedBy = input.getAttribute('aria-describedby');
-    expect(describedBy).toContain('existing-id');
-    expect(describedBy).toContain(element.id);
-  });
+		const describedBy = input.getAttribute('aria-describedby');
+		expect(describedBy).toContain('existing-id');
+		expect(describedBy).toContain(element.id);
+	});
 
-  describe('property reflection', () => {
-    it('should reflect fieldId property to the for attribute', () => {
-      const otherInput = document.createElement('input');
-      otherInput.id = 'other-input';
-      document.body.appendChild(otherInput);
+	describe('property reflection', () => {
+		it('should reflect fieldId property to the for attribute', () => {
+			const otherInput = document.createElement('input');
+			otherInput.id = 'other-input';
+			document.body.appendChild(otherInput);
 
-      const localElement = document.createElement('form-validation-list');
-      document.body.appendChild(localElement);
+			const localElement = document.createElement('form-validation-list');
+			document.body.appendChild(localElement);
 
-      localElement.fieldId = 'other-input';
-      expect(localElement.getAttribute('for')).toBe('other-input');
-    });
+			localElement.fieldId = 'other-input';
+			expect(localElement.getAttribute('for')).toBe('other-input');
+		});
 
-    it('should reflect triggerEvent property to the attribute', () => {
-      const localElement = document.createElement('form-validation-list');
-      localElement.triggerEvent = 'blur';
-      expect(localElement.getAttribute('trigger-event')).toBe('blur');
-    });
+		it('should reflect triggerEvent property to the attribute', () => {
+			const localElement = document.createElement('form-validation-list');
+			localElement.triggerEvent = 'blur';
+			expect(localElement.getAttribute('trigger-event')).toBe('blur');
+		});
 
-    it('should normalize unsupported trigger events to input', () => {
-      const localElement = document.createElement('form-validation-list');
-      localElement.triggerEvent = 'change';
-      expect(localElement.getAttribute('trigger-event')).toBe('input');
-      expect(localElement.triggerEvent).toBe('input');
-    });
+		it('should normalize unsupported trigger events to input', () => {
+			const localElement = document.createElement('form-validation-list');
+			localElement.triggerEvent = 'change';
+			expect(localElement.getAttribute('trigger-event')).toBe('input');
+			expect(localElement.triggerEvent).toBe('input');
+		});
 
-    it('should upgrade properties set before connecting', async () => {
-      const upgradeInput = document.createElement('input');
-      upgradeInput.id = 'upgrade-input';
-      document.body.appendChild(upgradeInput);
+		it('should upgrade properties set before connecting', async () => {
+			const upgradeInput = document.createElement('input');
+			upgradeInput.id = 'upgrade-input';
+			document.body.appendChild(upgradeInput);
 
-      const localElement = document.createElement('form-validation-list');
-      localElement.fieldId = 'upgrade-input';
-      localElement.triggerEvent = 'blur';
-      localElement.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-      localElement.setAttribute('each-delay', '0');
-      document.body.appendChild(localElement);
+			const localElement = document.createElement('form-validation-list');
+			localElement.fieldId = 'upgrade-input';
+			localElement.triggerEvent = 'blur';
+			localElement.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+			localElement.setAttribute('each-delay', '0');
+			document.body.appendChild(localElement);
 
-      upgradeInput.value = 'TEST';
-      upgradeInput.dispatchEvent(new Event('blur'));
+			upgradeInput.value = 'TEST';
+			upgradeInput.dispatchEvent(new Event('blur'));
 
-      await waitFor(() => {
-        expect(
-          localElement
-            .querySelector('[data-pattern]')
-            .classList.contains('validation-matched'),
-        ).toBe(true);
-      });
-    });
-  });
+			await waitFor(() => {
+				expect(
+					localElement
+						.querySelector('[data-pattern]')
+						.classList.contains('validation-matched'),
+				).toBe(true);
+			});
+		});
+	});
 
-  describe('validation rules', () => {
-    beforeEach(() => {
-      element.innerHTML = `
+	describe('validation rules', () => {
+		beforeEach(() => {
+			element.innerHTML = `
 				<ul>
 					<li data-pattern="[A-Z]+">At least one capital letter</li>
 					<li data-pattern="[a-z]+">At least one lowercase letter</li>
 					<li data-pattern="[0-9]+">At least one number</li>
 				</ul>
 			`;
-      element.setAttribute('each-delay', '0');
-
-      // Trigger connectedCallback again to pick up new rules
-      element.disconnectedCallback();
-      element.connectedCallback();
-    });
-
-    it('should find all validation rules', () => {
-      expect(element._rules.length).toBe(3);
-    });
-
-    it('should not force role="listitem" on rule elements', () => {
-      const rules = element.querySelectorAll('[data-pattern]');
-      rules.forEach((rule) => {
-        expect(rule.hasAttribute('role')).toBe(false);
-      });
-    });
-
-    it('should set aria-atomic on rule elements (not aria-live)', () => {
-      const rules = element.querySelectorAll('[data-pattern]');
-      rules.forEach((rule) => {
-        expect(rule.getAttribute('aria-atomic')).toBe('true');
-        expect(rule.hasAttribute('aria-live')).toBe(false);
-      });
-    });
-
-    it('should validate input value against rules', async () => {
-      input.value = 'Test123';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        const rules = element.querySelectorAll('[data-pattern]');
-        expect(rules[0].classList.contains('validation-matched')).toBe(
-          true,
-        );
-        expect(rules[1].classList.contains('validation-matched')).toBe(
-          true,
-        );
-        expect(rules[2].classList.contains('validation-matched')).toBe(
-          true,
-        );
-      });
-    });
-
-    it('should mark unmatched rules', async () => {
-      input.value = 'test'; // Only lowercase
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        const rules = element.querySelectorAll('[data-pattern]');
-        expect(
-          rules[0].classList.contains('validation-unmatched'),
-        ).toBe(true);
-        expect(rules[1].classList.contains('validation-matched')).toBe(
-          true,
-        );
-        expect(
-          rules[2].classList.contains('validation-unmatched'),
-        ).toBe(true);
-      });
-    });
-
-    it('should add validation classes to the input field', async () => {
-      input.value = 'Test123';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(input.classList.contains('validation-valid')).toBe(true);
-        expect(input.classList.contains('validation-invalid')).toBe(
-          false,
-        );
-      });
-    });
-
-    it('should update field custom validity', async () => {
-      input.value = 'test'; // Invalid
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(input.validationMessage).toBeTruthy();
-      });
-
-      input.value = 'Test123'; // Valid
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(input.validationMessage).toBe('');
-      });
-    });
-
-    it('should replace all placeholders in validation-message template', async () => {
-      element.setAttribute(
-        'validation-message',
-        'Matched {matched}/{matched} of {total}/{total}',
-      );
-      element.setAttribute('each-delay', '0');
-      element.setAttribute('input-throttle', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      input.value = 'test';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(input.validationMessage).toBe('Matched 1/1 of 3/3');
-      });
-    });
-
-    it('should fire validation event', () => {
-      return new Promise((resolve) => {
-        element.addEventListener(
-          'form-validation-list:validated',
-          (e) => {
-            expect(e.detail.isValid).toBeDefined();
-            expect(e.detail.matchedRules).toBeDefined();
-            expect(e.detail.totalRules).toBe(3);
-            expect(e.detail.field).toBe(input);
-            resolve();
-          },
-        );
-
-        input.value = 'Test123';
-        input.dispatchEvent(new Event('input'));
-      });
-    });
-
-    it('should create a live region with aria-live and aria-atomic', () => {
-      const liveRegion = document.querySelector(
-        '.form-validation-list-live-region',
-      );
-      expect(liveRegion).toBeTruthy();
-      expect(liveRegion.getAttribute('aria-live')).toBe('polite');
-      expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
-    });
-
-    it('should update the live region with the announcement after validation', async () => {
-      element.setAttribute('each-delay', '0');
-      element.setAttribute('input-throttle', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      input.value = 'Test123';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        const liveRegion = document.querySelector(
-          '.form-validation-list-live-region',
-        );
-        expect(liveRegion.textContent).toContain('3');
-      });
-    });
-
-    it('should replace all matched and total placeholders in announcement', async () => {
-      element.setAttribute(
-        'announcement',
-        'Matched {matched}/{matched} of {total}/{total}',
-      );
-      element.setAttribute('each-delay', '0');
-      element.setAttribute('input-throttle', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      input.value = 'Test123';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        const liveRegion = document.querySelector(
-          '.form-validation-list-live-region',
-        );
-        expect(liveRegion.textContent).toBe('Matched 3/3 of 3/3');
-      });
-    });
-
-    it('should suspend aria-describedby on input and restore on blur', () => {
-      vi.useFakeTimers();
-
-      try {
-        element.setAttribute('each-delay', '0');
-        element.setAttribute('input-throttle', '0');
-        element.disconnectedCallback();
-        element.connectedCallback();
-
-        const listId = element.id;
-        expect(input.getAttribute('aria-describedby')).toContain(
-          listId,
-        );
-
-        input.value = 'A';
-        input.dispatchEvent(new Event('input'));
-        const describedByDuringTyping =
-          input.getAttribute('aria-describedby');
-        expect(
-          describedByDuringTyping === null ||
-          !describedByDuringTyping.includes(listId),
-        ).toBe(true);
-
-        input.dispatchEvent(new Event('blur'));
-        const describedByAfterBlur =
-          input.getAttribute('aria-describedby');
-        expect(
-          describedByAfterBlur === null ||
-          !describedByAfterBlur.includes(listId),
-        ).toBe(true);
-
-        vi.advanceTimersByTime(200);
-        expect(input.getAttribute('aria-describedby')).toContain(
-          listId,
-        );
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it('should toggle has-value class based on field content', async () => {
-      element.setAttribute('each-delay', '0');
-      element.setAttribute('input-throttle', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      expect(element.classList.contains('has-value')).toBe(false);
-
-      input.value = 'A';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(element.classList.contains('has-value')).toBe(true);
-      });
-
-      input.value = '';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(element.classList.contains('has-value')).toBe(false);
-      });
-    });
-  });
-
-  describe('configuration attributes', () => {
-    it('should use default trigger event', () => {
-      expect(element.triggerEvent).toBe('input');
-    });
-
-    it('should allow custom trigger event', () => {
-      element.setAttribute('trigger-event', 'blur');
-      expect(element.triggerEvent).toBe('blur');
-    });
-
-    it('should use default each-delay', () => {
-      expect(element.eachDelay).toBe(150);
-    });
-
-    it('should use default input-throttle', () => {
-      expect(element.inputThrottle).toBe(250);
-    });
-
-    it('should allow custom input-throttle', () => {
-      element.setAttribute('input-throttle', '40');
-      expect(element.inputThrottle).toBe(40);
-    });
-
-    it('should allow custom each-delay', () => {
-      element.setAttribute('each-delay', '200');
-      expect(element.eachDelay).toBe(200);
-    });
-
-    it('should use default class names', () => {
-      expect(element.fieldInvalidClass).toBe('validation-invalid');
-      expect(element.fieldValidClass).toBe('validation-valid');
-      expect(element.ruleUnmatchedClass).toBe('validation-unmatched');
-      expect(element.ruleMatchedClass).toBe('validation-matched');
-    });
-
-    it('should use default icon alt text', () => {
-      expect(element.ruleMatchedAlt).toBe('Criteria met');
-      expect(element.ruleUnmatchedAlt).toBe('Criteria not met');
-    });
-
-    it('should allow custom icon alt text', () => {
-      element.setAttribute('rule-matched-alt', 'Met');
-      element.setAttribute('rule-unmatched-alt', 'Not met');
-      expect(element.ruleMatchedAlt).toBe('Met');
-      expect(element.ruleUnmatchedAlt).toBe('Not met');
-    });
-
-    it('should use default announcement template', () => {
-      expect(element.announcement).toBe(
-        'Criteria met: {matched} of {total}',
-      );
-    });
-
-    it('should allow custom announcement template', () => {
-      element.setAttribute('announcement', '{matched}/{total} ok');
-      expect(element.announcement).toBe('{matched}/{total} ok');
-    });
-
-    it('should allow custom icons via attribute', () => {
-      element.setAttribute('rule-matched-icon', '✅');
-      element.setAttribute('rule-unmatched-icon', '❌');
-      expect(element.ruleMatchedIcon).toBe('✅');
-      expect(element.ruleUnmatchedIcon).toBe('❌');
-    });
-
-    it('should allow custom class names', () => {
-      element.setAttribute('field-invalid-class', 'custom-invalid');
-      element.setAttribute('field-valid-class', 'custom-valid');
-      element.setAttribute('rule-unmatched-class', 'custom-unmatched');
-      element.setAttribute('rule-matched-class', 'custom-matched');
-
-      expect(element.fieldInvalidClass).toBe('custom-invalid');
-      expect(element.fieldValidClass).toBe('custom-valid');
-      expect(element.ruleUnmatchedClass).toBe('custom-unmatched');
-      expect(element.ruleMatchedClass).toBe('custom-matched');
-    });
-
-    it('should rebind validation handler when trigger-event changes', async () => {
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-      element.setAttribute('each-delay', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      element.setAttribute('trigger-event', 'blur');
-      input.value = 'TEST';
-      input.dispatchEvent(new Event('blur'));
-
-      await waitFor(() => {
-        expect(
-          element
-            .querySelector('[data-pattern]')
-            .classList.contains('validation-matched'),
-        ).toBe(true);
-      });
-    });
-
-    it('should refresh field classes when field-valid-class changes', async () => {
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-      element.setAttribute('each-delay', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      input.value = 'TEST';
-      input.dispatchEvent(new Event('input'));
-      await waitFor(() => {
-        expect(input.classList.contains('validation-valid')).toBe(true);
-      });
-
-      element.setAttribute('field-valid-class', 'custom-good');
-      await waitFor(() => {
-        expect(input.classList.contains('custom-good')).toBe(true);
-        expect(input.classList.contains('validation-valid')).toBe(
-          false,
-        );
-      });
-    });
-
-    it('should refresh rule classes when rule-matched-class changes', async () => {
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-      element.setAttribute('each-delay', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      input.value = 'TEST';
-      input.dispatchEvent(new Event('input'));
-      await waitFor(() => {
-        expect(
-          element
-            .querySelector('[data-pattern]')
-            .classList.contains('validation-matched'),
-        ).toBe(true);
-      });
-
-      element.setAttribute('rule-matched-class', 'custom-match');
-      await waitFor(() => {
-        const rule = element.querySelector('[data-pattern]');
-        expect(rule.classList.contains('custom-match')).toBe(true);
-        expect(rule.classList.contains('validation-matched')).toBe(
-          false,
-        );
-      });
-    });
-
-    it('should throttle input-triggered validation and use latest value', () => {
-      vi.useFakeTimers();
-
-      try {
-        element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-        element.setAttribute('each-delay', '0');
-        element.setAttribute('input-throttle', '100');
-        element.disconnectedCallback();
-        element.connectedCallback();
-
-        const rule = element.querySelector('[data-pattern]');
-
-        input.value = 'abc';
-        input.dispatchEvent(new Event('input'));
-
-        input.value = 'ABC';
-        input.dispatchEvent(new Event('input'));
-
-        expect(rule.classList.contains('validation-matched')).toBe(
-          false,
-        );
-        expect(rule.classList.contains('validation-unmatched')).toBe(
-          false,
-        );
-
-        vi.advanceTimersByTime(100);
-
-        expect(rule.classList.contains('validation-matched')).toBe(
-          true,
-        );
-        expect(rule.classList.contains('validation-unmatched')).toBe(
-          false,
-        );
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it('should not throttle blur trigger events', () => {
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-      element.setAttribute('trigger-event', 'blur');
-      element.setAttribute('input-throttle', '1000');
-      element.setAttribute('each-delay', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      const rule = element.querySelector('[data-pattern]');
-      input.value = 'ABC';
-      input.dispatchEvent(new Event('blur'));
-
-      expect(rule.classList.contains('validation-matched')).toBe(true);
-      expect(rule.classList.contains('validation-unmatched')).toBe(false);
-    });
-  });
-
-  describe('public API', () => {
-    beforeEach(() => {
-      element.innerHTML = `
+			element.setAttribute('each-delay', '0');
+
+			// Trigger connectedCallback again to pick up new rules
+			element.disconnectedCallback();
+			element.connectedCallback();
+		});
+
+		it('should find all validation rules', () => {
+			expect(element._rules.length).toBe(3);
+		});
+
+		it('should not force role="listitem" on rule elements', () => {
+			const rules = element.querySelectorAll('[data-pattern]');
+			rules.forEach((rule) => {
+				expect(rule.hasAttribute('role')).toBe(false);
+			});
+		});
+
+		it('should set aria-atomic on rule elements (not aria-live)', () => {
+			const rules = element.querySelectorAll('[data-pattern]');
+			rules.forEach((rule) => {
+				expect(rule.getAttribute('aria-atomic')).toBe('true');
+				expect(rule.hasAttribute('aria-live')).toBe(false);
+			});
+		});
+
+		it('should validate input value against rules', async () => {
+			input.value = 'Test123';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				const rules = element.querySelectorAll('[data-pattern]');
+				expect(rules[0].classList.contains('validation-matched')).toBe(
+					true,
+				);
+				expect(rules[1].classList.contains('validation-matched')).toBe(
+					true,
+				);
+				expect(rules[2].classList.contains('validation-matched')).toBe(
+					true,
+				);
+			});
+		});
+
+		it('should mark unmatched rules', async () => {
+			input.value = 'test'; // Only lowercase
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				const rules = element.querySelectorAll('[data-pattern]');
+				expect(
+					rules[0].classList.contains('validation-unmatched'),
+				).toBe(true);
+				expect(rules[1].classList.contains('validation-matched')).toBe(
+					true,
+				);
+				expect(
+					rules[2].classList.contains('validation-unmatched'),
+				).toBe(true);
+			});
+		});
+
+		it('should add validation classes to the input field', async () => {
+			input.value = 'Test123';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(input.classList.contains('validation-valid')).toBe(true);
+				expect(input.classList.contains('validation-invalid')).toBe(
+					false,
+				);
+			});
+		});
+
+		it('should update field custom validity', async () => {
+			input.value = 'test'; // Invalid
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(input.validationMessage).toBeTruthy();
+			});
+
+			input.value = 'Test123'; // Valid
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(input.validationMessage).toBe('');
+			});
+		});
+
+		it('should replace all placeholders in validation-message template', async () => {
+			element.setAttribute(
+				'validation-message',
+				'Matched {matched}/{matched} of {total}/{total}',
+			);
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'test';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(input.validationMessage).toBe('Matched 1/1 of 3/3');
+			});
+		});
+
+		it('should fire validation event', () => {
+			return new Promise((resolve) => {
+				element.addEventListener(
+					'form-validation-list:validated',
+					(e) => {
+						expect(e.detail.isValid).toBeDefined();
+						expect(e.detail.matchedRules).toBeDefined();
+						expect(e.detail.totalRules).toBe(3);
+						expect(e.detail.field).toBe(input);
+						resolve();
+					},
+				);
+
+				input.value = 'Test123';
+				input.dispatchEvent(new Event('input'));
+			});
+		});
+
+		it('should create a live region with aria-live and aria-atomic', () => {
+			const liveRegion = document.querySelector(
+				'.form-validation-list-live-region',
+			);
+			expect(liveRegion).toBeTruthy();
+			expect(liveRegion.getAttribute('aria-live')).toBe('polite');
+			expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
+		});
+
+		it('should update the live region with the announcement after validation', async () => {
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'Test123';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				const liveRegion = document.querySelector(
+					'.form-validation-list-live-region',
+				);
+				expect(liveRegion.textContent).toContain('3');
+			});
+		});
+
+		it('should replace all matched and total placeholders in announcement', async () => {
+			element.setAttribute(
+				'announcement',
+				'Matched {matched}/{matched} of {total}/{total}',
+			);
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'Test123';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				const liveRegion = document.querySelector(
+					'.form-validation-list-live-region',
+				);
+				expect(liveRegion.textContent).toBe('Matched 3/3 of 3/3');
+			});
+		});
+
+		it('should suspend aria-describedby on input and restore on blur', () => {
+			vi.useFakeTimers();
+
+			try {
+				element.setAttribute('each-delay', '0');
+				element.setAttribute('input-throttle', '0');
+				element.disconnectedCallback();
+				element.connectedCallback();
+
+				const listId = element.id;
+				expect(input.getAttribute('aria-describedby')).toContain(
+					listId,
+				);
+
+				input.value = 'A';
+				input.dispatchEvent(new Event('input'));
+				const describedByDuringTyping =
+					input.getAttribute('aria-describedby');
+				expect(
+					describedByDuringTyping === null ||
+						!describedByDuringTyping.includes(listId),
+				).toBe(true);
+
+				input.dispatchEvent(new Event('blur'));
+				const describedByAfterBlur =
+					input.getAttribute('aria-describedby');
+				expect(
+					describedByAfterBlur === null ||
+						!describedByAfterBlur.includes(listId),
+				).toBe(true);
+
+				vi.advanceTimersByTime(200);
+				expect(input.getAttribute('aria-describedby')).toContain(
+					listId,
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should toggle has-value class based on field content', async () => {
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			expect(element.classList.contains('has-value')).toBe(false);
+
+			input.value = 'A';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(element.classList.contains('has-value')).toBe(true);
+			});
+
+			input.value = '';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(element.classList.contains('has-value')).toBe(false);
+			});
+		});
+	});
+
+	describe('configuration attributes', () => {
+		it('should use default trigger event', () => {
+			expect(element.triggerEvent).toBe('input');
+		});
+
+		it('should allow custom trigger event', () => {
+			element.setAttribute('trigger-event', 'blur');
+			expect(element.triggerEvent).toBe('blur');
+		});
+
+		it('should use default each-delay', () => {
+			expect(element.eachDelay).toBe(150);
+		});
+
+		it('should use default input-throttle', () => {
+			expect(element.inputThrottle).toBe(250);
+		});
+
+		it('should allow custom input-throttle', () => {
+			element.setAttribute('input-throttle', '40');
+			expect(element.inputThrottle).toBe(40);
+		});
+
+		it('should allow custom each-delay', () => {
+			element.setAttribute('each-delay', '200');
+			expect(element.eachDelay).toBe(200);
+		});
+
+		it('should use default class names', () => {
+			expect(element.fieldInvalidClass).toBe('validation-invalid');
+			expect(element.fieldValidClass).toBe('validation-valid');
+			expect(element.ruleUnmatchedClass).toBe('validation-unmatched');
+			expect(element.ruleMatchedClass).toBe('validation-matched');
+		});
+
+		it('should use default icon alt text', () => {
+			expect(element.ruleMatchedAlt).toBe('Criteria met');
+			expect(element.ruleUnmatchedAlt).toBe('Criteria not met');
+		});
+
+		it('should allow custom icon alt text', () => {
+			element.setAttribute('rule-matched-alt', 'Met');
+			element.setAttribute('rule-unmatched-alt', 'Not met');
+			expect(element.ruleMatchedAlt).toBe('Met');
+			expect(element.ruleUnmatchedAlt).toBe('Not met');
+		});
+
+		it('should use default announcement template', () => {
+			expect(element.announcement).toBe(
+				'Criteria met: {matched} of {total}',
+			);
+		});
+
+		it('should allow custom announcement template', () => {
+			element.setAttribute('announcement', '{matched}/{total} ok');
+			expect(element.announcement).toBe('{matched}/{total} ok');
+		});
+
+		it('should allow custom icons via attribute', () => {
+			element.setAttribute('rule-matched-icon', '✅');
+			element.setAttribute('rule-unmatched-icon', '❌');
+			expect(element.ruleMatchedIcon).toBe('✅');
+			expect(element.ruleUnmatchedIcon).toBe('❌');
+		});
+
+		it('should allow custom class names', () => {
+			element.setAttribute('field-invalid-class', 'custom-invalid');
+			element.setAttribute('field-valid-class', 'custom-valid');
+			element.setAttribute('rule-unmatched-class', 'custom-unmatched');
+			element.setAttribute('rule-matched-class', 'custom-matched');
+
+			expect(element.fieldInvalidClass).toBe('custom-invalid');
+			expect(element.fieldValidClass).toBe('custom-valid');
+			expect(element.ruleUnmatchedClass).toBe('custom-unmatched');
+			expect(element.ruleMatchedClass).toBe('custom-matched');
+		});
+
+		it('should rebind validation handler when trigger-event changes', async () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			element.setAttribute('trigger-event', 'blur');
+			input.value = 'TEST';
+			input.dispatchEvent(new Event('blur'));
+
+			await waitFor(() => {
+				expect(
+					element
+						.querySelector('[data-pattern]')
+						.classList.contains('validation-matched'),
+				).toBe(true);
+			});
+		});
+
+		it('should refresh field classes when field-valid-class changes', async () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'TEST';
+			input.dispatchEvent(new Event('input'));
+			await waitFor(() => {
+				expect(input.classList.contains('validation-valid')).toBe(true);
+			});
+
+			element.setAttribute('field-valid-class', 'custom-good');
+			await waitFor(() => {
+				expect(input.classList.contains('custom-good')).toBe(true);
+				expect(input.classList.contains('validation-valid')).toBe(
+					false,
+				);
+			});
+		});
+
+		it('should refresh rule classes when rule-matched-class changes', async () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'TEST';
+			input.dispatchEvent(new Event('input'));
+			await waitFor(() => {
+				expect(
+					element
+						.querySelector('[data-pattern]')
+						.classList.contains('validation-matched'),
+				).toBe(true);
+			});
+
+			element.setAttribute('rule-matched-class', 'custom-match');
+			await waitFor(() => {
+				const rule = element.querySelector('[data-pattern]');
+				expect(rule.classList.contains('custom-match')).toBe(true);
+				expect(rule.classList.contains('validation-matched')).toBe(
+					false,
+				);
+			});
+		});
+
+		it('should throttle input-triggered validation and use latest value', () => {
+			vi.useFakeTimers();
+
+			try {
+				element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+				element.setAttribute('each-delay', '0');
+				element.setAttribute('input-throttle', '100');
+				element.disconnectedCallback();
+				element.connectedCallback();
+
+				const rule = element.querySelector('[data-pattern]');
+
+				input.value = 'abc';
+				input.dispatchEvent(new Event('input'));
+
+				input.value = 'ABC';
+				input.dispatchEvent(new Event('input'));
+
+				expect(rule.classList.contains('validation-matched')).toBe(
+					false,
+				);
+				expect(rule.classList.contains('validation-unmatched')).toBe(
+					false,
+				);
+
+				vi.advanceTimersByTime(100);
+
+				expect(rule.classList.contains('validation-matched')).toBe(
+					true,
+				);
+				expect(rule.classList.contains('validation-unmatched')).toBe(
+					false,
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should not throttle blur trigger events', () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+			element.setAttribute('trigger-event', 'blur');
+			element.setAttribute('input-throttle', '1000');
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			const rule = element.querySelector('[data-pattern]');
+			input.value = 'ABC';
+			input.dispatchEvent(new Event('blur'));
+
+			expect(rule.classList.contains('validation-matched')).toBe(true);
+			expect(rule.classList.contains('validation-unmatched')).toBe(false);
+		});
+	});
+
+	describe('public API', () => {
+		beforeEach(() => {
+			element.innerHTML = `
 				<ul>
 					<li data-pattern="[A-Z]+">Capital letter</li>
 					<li data-pattern="[0-9]+">Number</li>
 				</ul>
 			`;
-      element.disconnectedCallback();
-      element.connectedCallback();
-    });
+			element.disconnectedCallback();
+			element.connectedCallback();
+		});
 
-    it('should provide validate() method', () => {
-      expect(typeof element.validate).toBe('function');
-    });
+		it('should provide validate() method', () => {
+			expect(typeof element.validate).toBe('function');
+		});
 
-    it('validate() should return validation state', () => {
-      input.value = 'Test123';
-      const isValid = element.validate();
-      expect(typeof isValid).toBe('boolean');
-    });
+		it('validate() should return validation state', () => {
+			input.value = 'Test123';
+			const isValid = element.validate();
+			expect(typeof isValid).toBe('boolean');
+		});
 
-    it('should provide isValid getter', () => {
-      input.value = 'Test123';
-      element.validate();
-      expect(typeof element.isValid).toBe('boolean');
-    });
-  });
+		it('should provide isValid getter', () => {
+			input.value = 'Test123';
+			element.validate();
+			expect(typeof element.isValid).toBe('boolean');
+		});
+	});
 
-  describe('cleanup', () => {
-    it('should remove only this id from aria-describedby when disconnected', () => {
-      input.setAttribute('aria-describedby', 'existing-id');
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-      element.disconnectedCallback();
-      element.connectedCallback();
+	describe('cleanup', () => {
+		it('should remove only this id from aria-describedby when disconnected', () => {
+			input.setAttribute('aria-describedby', 'existing-id');
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+			element.disconnectedCallback();
+			element.connectedCallback();
 
-      const listId = element.id;
-      expect(input.getAttribute('aria-describedby')).toContain(
-        'existing-id',
-      );
-      expect(input.getAttribute('aria-describedby')).toContain(listId);
+			const listId = element.id;
+			expect(input.getAttribute('aria-describedby')).toContain(
+				'existing-id',
+			);
+			expect(input.getAttribute('aria-describedby')).toContain(listId);
 
-      element.disconnectedCallback();
+			element.disconnectedCallback();
 
-      expect(input.getAttribute('aria-describedby')).toBe('existing-id');
-    });
+			expect(input.getAttribute('aria-describedby')).toBe('existing-id');
+		});
 
-    it('should cleanup when disconnected', async () => {
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-      element.setAttribute('each-delay', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
+		it('should cleanup when disconnected', async () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
 
-      input.value = 'Test';
-      input.dispatchEvent(new Event('input'));
-      await waitFor(() => {
-        expect(input.classList.contains('validation-valid')).toBe(true);
-      });
+			input.value = 'Test';
+			input.dispatchEvent(new Event('input'));
+			await waitFor(() => {
+				expect(input.classList.contains('validation-valid')).toBe(true);
+			});
 
-      element.disconnectedCallback();
+			element.disconnectedCallback();
 
-      // Field should not have validation classes after cleanup
-      expect(input.classList.contains('validation-valid')).toBe(false);
-      expect(input.classList.contains('validation-invalid')).toBe(false);
-    });
+			// Field should not have validation classes after cleanup
+			expect(input.classList.contains('validation-valid')).toBe(false);
+			expect(input.classList.contains('validation-invalid')).toBe(false);
+		});
 
-    it('should cleanup when for attribute changes', () => {
-      const nextInput = document.createElement('input');
-      nextInput.type = 'text';
-      nextInput.id = 'next-input';
-      document.body.appendChild(nextInput);
+		it('should cleanup when for attribute changes', () => {
+			const nextInput = document.createElement('input');
+			nextInput.type = 'text';
+			nextInput.id = 'next-input';
+			document.body.appendChild(nextInput);
 
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-      element.disconnectedCallback();
-      element.connectedCallback();
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+			element.disconnectedCallback();
+			element.connectedCallback();
 
-      const oldField = element._field;
-      oldField.setAttribute('aria-describedby', 'existing-id');
-      element._setupAccessibility();
+			const oldField = element._field;
+			oldField.setAttribute('aria-describedby', 'existing-id');
+			element._setupAccessibility();
 
-      element.setAttribute('for', 'next-input');
+			element.setAttribute('for', 'next-input');
 
-      expect(element._field).not.toBe(oldField);
-      expect(oldField.getAttribute('aria-describedby')).toBe(
-        'existing-id',
-      );
-    });
-  });
+			expect(element._field).not.toBe(oldField);
+			expect(oldField.getAttribute('aria-describedby')).toBe(
+				'existing-id',
+			);
+		});
+	});
 });

--- a/test/form-validation-list.test.js
+++ b/test/form-validation-list.test.js
@@ -145,11 +145,11 @@ describe('FormValidationListElement', () => {
 			});
 		});
 
-		it('should set aria-live and aria-atomic on rule elements', () => {
+		it('should set aria-atomic on rule elements (not aria-live)', () => {
 			const rules = element.querySelectorAll('[data-pattern]');
 			rules.forEach((rule) => {
-				expect(rule.getAttribute('aria-live')).toBe('polite');
 				expect(rule.getAttribute('aria-atomic')).toBe('true');
+				expect(rule.hasAttribute('aria-live')).toBe(false);
 			});
 		});
 
@@ -234,6 +234,94 @@ describe('FormValidationListElement', () => {
 				input.dispatchEvent(new Event('input'));
 			});
 		});
+
+		it('should create a live region with aria-live and aria-atomic', () => {
+			const liveRegion = element.querySelector(
+				'.form-validation-list-live-region',
+			);
+			expect(liveRegion).toBeTruthy();
+			expect(liveRegion.getAttribute('aria-live')).toBe('polite');
+			expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
+		});
+
+		it('should update the live region with the announcement after validation', async () => {
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'Test123';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				const liveRegion = element.querySelector(
+					'.form-validation-list-live-region',
+				);
+				expect(liveRegion.textContent).toContain('3');
+			});
+		});
+
+		it('should suspend aria-describedby on input and restore on blur', () => {
+			vi.useFakeTimers();
+
+			try {
+				element.setAttribute('each-delay', '0');
+				element.setAttribute('input-throttle', '0');
+				element.disconnectedCallback();
+				element.connectedCallback();
+
+				const listId = element.id;
+				expect(input.getAttribute('aria-describedby')).toContain(
+					listId,
+				);
+
+				input.value = 'A';
+				input.dispatchEvent(new Event('input'));
+				const describedByDuringTyping =
+					input.getAttribute('aria-describedby');
+				expect(
+					describedByDuringTyping === null ||
+						!describedByDuringTyping.includes(listId),
+				).toBe(true);
+
+				input.dispatchEvent(new Event('blur'));
+				const describedByAfterBlur =
+					input.getAttribute('aria-describedby');
+				expect(
+					describedByAfterBlur === null ||
+						!describedByAfterBlur.includes(listId),
+				).toBe(true);
+
+				vi.advanceTimersByTime(200);
+				expect(input.getAttribute('aria-describedby')).toContain(
+					listId,
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should toggle has-value class based on field content', async () => {
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			expect(element.classList.contains('has-value')).toBe(false);
+
+			input.value = 'A';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(element.classList.contains('has-value')).toBe(true);
+			});
+
+			input.value = '';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(element.classList.contains('has-value')).toBe(false);
+			});
+		});
 	});
 
 	describe('configuration attributes', () => {
@@ -269,6 +357,36 @@ describe('FormValidationListElement', () => {
 			expect(element.fieldValidClass).toBe('validation-valid');
 			expect(element.ruleUnmatchedClass).toBe('validation-unmatched');
 			expect(element.ruleMatchedClass).toBe('validation-matched');
+		});
+
+		it('should use default icon alt text', () => {
+			expect(element.ruleMatchedAlt).toBe('Criteria met');
+			expect(element.ruleUnmatchedAlt).toBe('Criteria not met');
+		});
+
+		it('should allow custom icon alt text', () => {
+			element.setAttribute('rule-matched-alt', 'Met');
+			element.setAttribute('rule-unmatched-alt', 'Not met');
+			expect(element.ruleMatchedAlt).toBe('Met');
+			expect(element.ruleUnmatchedAlt).toBe('Not met');
+		});
+
+		it('should use default announcement template', () => {
+			expect(element.announcement).toBe(
+				'Criteria met: {matched} of {total}',
+			);
+		});
+
+		it('should allow custom announcement template', () => {
+			element.setAttribute('announcement', '{matched}/{total} ok');
+			expect(element.announcement).toBe('{matched}/{total} ok');
+		});
+
+		it('should allow custom icons via attribute', () => {
+			element.setAttribute('rule-matched-icon', '✅');
+			element.setAttribute('rule-unmatched-icon', '❌');
+			expect(element.ruleMatchedIcon).toBe('✅');
+			expect(element.ruleUnmatchedIcon).toBe('❌');
 		});
 
 		it('should allow custom class names', () => {

--- a/test/form-validation-list.test.js
+++ b/test/form-validation-list.test.js
@@ -3,651 +3,658 @@ import { waitFor } from '@testing-library/dom';
 import { FormValidationListElement } from '../form-validation-list.js';
 
 describe('FormValidationListElement', () => {
-	let element;
-	let input;
+  let element;
+  let input;
 
-	beforeEach(() => {
-		// Create a test input field
-		input = document.createElement('input');
-		input.type = 'text';
-		input.id = 'test-input';
-		document.body.appendChild(input);
+  beforeEach(() => {
+    // Create a test input field
+    input = document.createElement('input');
+    input.type = 'text';
+    input.id = 'test-input';
+    document.body.appendChild(input);
 
-		// Create the validation list element
-		element = document.createElement('form-validation-list');
-		element.setAttribute('for', 'test-input');
-		document.body.appendChild(element);
-	});
+    // Create the validation list element
+    element = document.createElement('form-validation-list');
+    element.setAttribute('for', 'test-input');
+    document.body.appendChild(element);
+  });
 
-	afterEach(() => {
-		document.body.innerHTML = '';
-	});
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
 
-	it('should be defined', () => {
-		expect(customElements.get('form-validation-list')).toBe(
-			FormValidationListElement,
-		);
-	});
+  it('should be defined', () => {
+    expect(customElements.get('form-validation-list')).toBe(
+      FormValidationListElement,
+    );
+  });
 
-	it('should create an instance', () => {
-		expect(element).toBeInstanceOf(FormValidationListElement);
-		expect(element).toBeInstanceOf(HTMLElement);
-	});
+  it('should create an instance', () => {
+    expect(element).toBeInstanceOf(FormValidationListElement);
+    expect(element).toBeInstanceOf(HTMLElement);
+  });
 
-	it('should not have a shadow root (uses light DOM)', () => {
-		expect(element.shadowRoot).toBeFalsy();
-	});
+  it('should not have a shadow root (uses light DOM)', () => {
+    expect(element.shadowRoot).toBeFalsy();
+  });
 
-	it('should not force role="list" on host', () => {
-		expect(element.hasAttribute('role')).toBe(false);
-	});
+  it('should not force role="list" on host', () => {
+    expect(element.hasAttribute('role')).toBe(false);
+  });
 
-	it('should find the associated input field', () => {
-		expect(element._field).toBe(input);
-	});
+  it('should find the associated input field', () => {
+    expect(element._field).toBe(input);
+  });
 
-	it('should set up aria-describedby on the input field', () => {
-		// Need to add rules for the element to set up aria-describedby
-		element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
-		element.disconnectedCallback();
-		element.connectedCallback();
+  it('should set up aria-describedby on the input field', () => {
+    // Need to add rules for the element to set up aria-describedby
+    element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
+    element.disconnectedCallback();
+    element.connectedCallback();
 
-		const describedBy = input.getAttribute('aria-describedby');
-		expect(describedBy).toBeTruthy();
-		expect(describedBy).toContain(element.id);
-	});
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(describedBy).toContain(element.id);
+  });
 
-	it('should preserve existing aria-describedby values', () => {
-		// Clean up previous element
-		element.remove();
+  it('should preserve existing aria-describedby values', () => {
+    // Clean up previous element
+    element.remove();
 
-		// Set existing describedby
-		input.setAttribute('aria-describedby', 'existing-id');
+    // Set existing describedby
+    input.setAttribute('aria-describedby', 'existing-id');
 
-		// Create new element
-		element = document.createElement('form-validation-list');
-		element.setAttribute('for', 'test-input');
-		document.body.appendChild(element);
+    // Create new element
+    element = document.createElement('form-validation-list');
+    element.setAttribute('for', 'test-input');
+    document.body.appendChild(element);
 
-		const describedBy = input.getAttribute('aria-describedby');
-		expect(describedBy).toContain('existing-id');
-		expect(describedBy).toContain(element.id);
-	});
+    const describedBy = input.getAttribute('aria-describedby');
+    expect(describedBy).toContain('existing-id');
+    expect(describedBy).toContain(element.id);
+  });
 
-	describe('property reflection', () => {
-		it('should reflect fieldId property to the for attribute', () => {
-			const otherInput = document.createElement('input');
-			otherInput.id = 'other-input';
-			document.body.appendChild(otherInput);
+  describe('property reflection', () => {
+    it('should reflect fieldId property to the for attribute', () => {
+      const otherInput = document.createElement('input');
+      otherInput.id = 'other-input';
+      document.body.appendChild(otherInput);
 
-			const localElement = document.createElement('form-validation-list');
-			document.body.appendChild(localElement);
+      const localElement = document.createElement('form-validation-list');
+      document.body.appendChild(localElement);
 
-			localElement.fieldId = 'other-input';
-			expect(localElement.getAttribute('for')).toBe('other-input');
-		});
+      localElement.fieldId = 'other-input';
+      expect(localElement.getAttribute('for')).toBe('other-input');
+    });
 
-		it('should reflect triggerEvent property to the attribute', () => {
-			const localElement = document.createElement('form-validation-list');
-			localElement.triggerEvent = 'change';
-			expect(localElement.getAttribute('trigger-event')).toBe('change');
-		});
+    it('should reflect triggerEvent property to the attribute', () => {
+      const localElement = document.createElement('form-validation-list');
+      localElement.triggerEvent = 'blur';
+      expect(localElement.getAttribute('trigger-event')).toBe('blur');
+    });
 
-		it('should upgrade properties set before connecting', async () => {
-			const upgradeInput = document.createElement('input');
-			upgradeInput.id = 'upgrade-input';
-			document.body.appendChild(upgradeInput);
+    it('should normalize unsupported trigger events to input', () => {
+      const localElement = document.createElement('form-validation-list');
+      localElement.triggerEvent = 'change';
+      expect(localElement.getAttribute('trigger-event')).toBe('input');
+      expect(localElement.triggerEvent).toBe('input');
+    });
 
-			const localElement = document.createElement('form-validation-list');
-			localElement.fieldId = 'upgrade-input';
-			localElement.triggerEvent = 'change';
-			localElement.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-			localElement.setAttribute('each-delay', '0');
-			document.body.appendChild(localElement);
+    it('should upgrade properties set before connecting', async () => {
+      const upgradeInput = document.createElement('input');
+      upgradeInput.id = 'upgrade-input';
+      document.body.appendChild(upgradeInput);
 
-			upgradeInput.value = 'TEST';
-			upgradeInput.dispatchEvent(new Event('change'));
+      const localElement = document.createElement('form-validation-list');
+      localElement.fieldId = 'upgrade-input';
+      localElement.triggerEvent = 'blur';
+      localElement.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+      localElement.setAttribute('each-delay', '0');
+      document.body.appendChild(localElement);
 
-			await waitFor(() => {
-				expect(
-					localElement
-						.querySelector('[data-pattern]')
-						.classList.contains('validation-matched'),
-				).toBe(true);
-			});
-		});
-	});
+      upgradeInput.value = 'TEST';
+      upgradeInput.dispatchEvent(new Event('blur'));
 
-	describe('validation rules', () => {
-		beforeEach(() => {
-			element.innerHTML = `
+      await waitFor(() => {
+        expect(
+          localElement
+            .querySelector('[data-pattern]')
+            .classList.contains('validation-matched'),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe('validation rules', () => {
+    beforeEach(() => {
+      element.innerHTML = `
 				<ul>
 					<li data-pattern="[A-Z]+">At least one capital letter</li>
 					<li data-pattern="[a-z]+">At least one lowercase letter</li>
 					<li data-pattern="[0-9]+">At least one number</li>
 				</ul>
 			`;
-			element.setAttribute('each-delay', '0');
-
-			// Trigger connectedCallback again to pick up new rules
-			element.disconnectedCallback();
-			element.connectedCallback();
-		});
-
-		it('should find all validation rules', () => {
-			expect(element._rules.length).toBe(3);
-		});
-
-		it('should not force role="listitem" on rule elements', () => {
-			const rules = element.querySelectorAll('[data-pattern]');
-			rules.forEach((rule) => {
-				expect(rule.hasAttribute('role')).toBe(false);
-			});
-		});
-
-		it('should set aria-atomic on rule elements (not aria-live)', () => {
-			const rules = element.querySelectorAll('[data-pattern]');
-			rules.forEach((rule) => {
-				expect(rule.getAttribute('aria-atomic')).toBe('true');
-				expect(rule.hasAttribute('aria-live')).toBe(false);
-			});
-		});
-
-		it('should validate input value against rules', async () => {
-			input.value = 'Test123';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				const rules = element.querySelectorAll('[data-pattern]');
-				expect(rules[0].classList.contains('validation-matched')).toBe(
-					true,
-				);
-				expect(rules[1].classList.contains('validation-matched')).toBe(
-					true,
-				);
-				expect(rules[2].classList.contains('validation-matched')).toBe(
-					true,
-				);
-			});
-		});
-
-		it('should mark unmatched rules', async () => {
-			input.value = 'test'; // Only lowercase
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				const rules = element.querySelectorAll('[data-pattern]');
-				expect(
-					rules[0].classList.contains('validation-unmatched'),
-				).toBe(true);
-				expect(rules[1].classList.contains('validation-matched')).toBe(
-					true,
-				);
-				expect(
-					rules[2].classList.contains('validation-unmatched'),
-				).toBe(true);
-			});
-		});
-
-		it('should add validation classes to the input field', async () => {
-			input.value = 'Test123';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(input.classList.contains('validation-valid')).toBe(true);
-				expect(input.classList.contains('validation-invalid')).toBe(
-					false,
-				);
-			});
-		});
-
-		it('should update field custom validity', async () => {
-			input.value = 'test'; // Invalid
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(input.validationMessage).toBeTruthy();
-			});
-
-			input.value = 'Test123'; // Valid
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(input.validationMessage).toBe('');
-			});
-		});
-
-		it('should replace all placeholders in validation-message template', async () => {
-			element.setAttribute(
-				'validation-message',
-				'Matched {matched}/{matched} of {total}/{total}',
-			);
-			element.setAttribute('each-delay', '0');
-			element.setAttribute('input-throttle', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			input.value = 'test';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(input.validationMessage).toBe('Matched 1/1 of 3/3');
-			});
-		});
-
-		it('should fire validation event', () => {
-			return new Promise((resolve) => {
-				element.addEventListener(
-					'form-validation-list:validated',
-					(e) => {
-						expect(e.detail.isValid).toBeDefined();
-						expect(e.detail.matchedRules).toBeDefined();
-						expect(e.detail.totalRules).toBe(3);
-						expect(e.detail.field).toBe(input);
-						resolve();
-					},
-				);
-
-				input.value = 'Test123';
-				input.dispatchEvent(new Event('input'));
-			});
-		});
-
-		it('should create a live region with aria-live and aria-atomic', () => {
-			const liveRegion = element.querySelector(
-				'.form-validation-list-live-region',
-			);
-			expect(liveRegion).toBeTruthy();
-			expect(liveRegion.getAttribute('aria-live')).toBe('polite');
-			expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
-		});
-
-		it('should update the live region with the announcement after validation', async () => {
-			element.setAttribute('each-delay', '0');
-			element.setAttribute('input-throttle', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			input.value = 'Test123';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				const liveRegion = element.querySelector(
-					'.form-validation-list-live-region',
-				);
-				expect(liveRegion.textContent).toContain('3');
-			});
-		});
-
-		it('should replace all matched and total placeholders in announcement', async () => {
-			element.setAttribute(
-				'announcement',
-				'Matched {matched}/{matched} of {total}/{total}',
-			);
-			element.setAttribute('each-delay', '0');
-			element.setAttribute('input-throttle', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			input.value = 'Test123';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				const liveRegion = element.querySelector(
-					'.form-validation-list-live-region',
-				);
-				expect(liveRegion.textContent).toBe('Matched 3/3 of 3/3');
-			});
-		});
-
-		it('should suspend aria-describedby on input and restore on blur', () => {
-			vi.useFakeTimers();
-
-			try {
-				element.setAttribute('each-delay', '0');
-				element.setAttribute('input-throttle', '0');
-				element.disconnectedCallback();
-				element.connectedCallback();
-
-				const listId = element.id;
-				expect(input.getAttribute('aria-describedby')).toContain(
-					listId,
-				);
-
-				input.value = 'A';
-				input.dispatchEvent(new Event('input'));
-				const describedByDuringTyping =
-					input.getAttribute('aria-describedby');
-				expect(
-					describedByDuringTyping === null ||
-						!describedByDuringTyping.includes(listId),
-				).toBe(true);
-
-				input.dispatchEvent(new Event('blur'));
-				const describedByAfterBlur =
-					input.getAttribute('aria-describedby');
-				expect(
-					describedByAfterBlur === null ||
-						!describedByAfterBlur.includes(listId),
-				).toBe(true);
-
-				vi.advanceTimersByTime(200);
-				expect(input.getAttribute('aria-describedby')).toContain(
-					listId,
-				);
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-
-		it('should toggle has-value class based on field content', async () => {
-			element.setAttribute('each-delay', '0');
-			element.setAttribute('input-throttle', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			expect(element.classList.contains('has-value')).toBe(false);
-
-			input.value = 'A';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(element.classList.contains('has-value')).toBe(true);
-			});
-
-			input.value = '';
-			input.dispatchEvent(new Event('input'));
-
-			await waitFor(() => {
-				expect(element.classList.contains('has-value')).toBe(false);
-			});
-		});
-	});
-
-	describe('configuration attributes', () => {
-		it('should use default trigger event', () => {
-			expect(element.triggerEvent).toBe('input');
-		});
-
-		it('should allow custom trigger event', () => {
-			element.setAttribute('trigger-event', 'keyup');
-			expect(element.triggerEvent).toBe('keyup');
-		});
-
-		it('should use default each-delay', () => {
-			expect(element.eachDelay).toBe(150);
-		});
-
-		it('should use default input-throttle', () => {
-			expect(element.inputThrottle).toBe(250);
-		});
-
-		it('should allow custom input-throttle', () => {
-			element.setAttribute('input-throttle', '40');
-			expect(element.inputThrottle).toBe(40);
-		});
-
-		it('should allow custom each-delay', () => {
-			element.setAttribute('each-delay', '200');
-			expect(element.eachDelay).toBe(200);
-		});
-
-		it('should use default class names', () => {
-			expect(element.fieldInvalidClass).toBe('validation-invalid');
-			expect(element.fieldValidClass).toBe('validation-valid');
-			expect(element.ruleUnmatchedClass).toBe('validation-unmatched');
-			expect(element.ruleMatchedClass).toBe('validation-matched');
-		});
-
-		it('should use default icon alt text', () => {
-			expect(element.ruleMatchedAlt).toBe('Criteria met');
-			expect(element.ruleUnmatchedAlt).toBe('Criteria not met');
-		});
-
-		it('should allow custom icon alt text', () => {
-			element.setAttribute('rule-matched-alt', 'Met');
-			element.setAttribute('rule-unmatched-alt', 'Not met');
-			expect(element.ruleMatchedAlt).toBe('Met');
-			expect(element.ruleUnmatchedAlt).toBe('Not met');
-		});
-
-		it('should use default announcement template', () => {
-			expect(element.announcement).toBe(
-				'Criteria met: {matched} of {total}',
-			);
-		});
-
-		it('should allow custom announcement template', () => {
-			element.setAttribute('announcement', '{matched}/{total} ok');
-			expect(element.announcement).toBe('{matched}/{total} ok');
-		});
-
-		it('should allow custom icons via attribute', () => {
-			element.setAttribute('rule-matched-icon', '✅');
-			element.setAttribute('rule-unmatched-icon', '❌');
-			expect(element.ruleMatchedIcon).toBe('✅');
-			expect(element.ruleUnmatchedIcon).toBe('❌');
-		});
-
-		it('should allow custom class names', () => {
-			element.setAttribute('field-invalid-class', 'custom-invalid');
-			element.setAttribute('field-valid-class', 'custom-valid');
-			element.setAttribute('rule-unmatched-class', 'custom-unmatched');
-			element.setAttribute('rule-matched-class', 'custom-matched');
-
-			expect(element.fieldInvalidClass).toBe('custom-invalid');
-			expect(element.fieldValidClass).toBe('custom-valid');
-			expect(element.ruleUnmatchedClass).toBe('custom-unmatched');
-			expect(element.ruleMatchedClass).toBe('custom-matched');
-		});
-
-		it('should rebind validation handler when trigger-event changes', async () => {
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-			element.setAttribute('each-delay', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			element.setAttribute('trigger-event', 'change');
-			input.value = 'TEST';
-			input.dispatchEvent(new Event('change'));
-
-			await waitFor(() => {
-				expect(
-					element
-						.querySelector('[data-pattern]')
-						.classList.contains('validation-matched'),
-				).toBe(true);
-			});
-		});
-
-		it('should refresh field classes when field-valid-class changes', async () => {
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-			element.setAttribute('each-delay', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			input.value = 'TEST';
-			input.dispatchEvent(new Event('input'));
-			await waitFor(() => {
-				expect(input.classList.contains('validation-valid')).toBe(true);
-			});
-
-			element.setAttribute('field-valid-class', 'custom-good');
-			await waitFor(() => {
-				expect(input.classList.contains('custom-good')).toBe(true);
-				expect(input.classList.contains('validation-valid')).toBe(
-					false,
-				);
-			});
-		});
-
-		it('should refresh rule classes when rule-matched-class changes', async () => {
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-			element.setAttribute('each-delay', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			input.value = 'TEST';
-			input.dispatchEvent(new Event('input'));
-			await waitFor(() => {
-				expect(
-					element
-						.querySelector('[data-pattern]')
-						.classList.contains('validation-matched'),
-				).toBe(true);
-			});
-
-			element.setAttribute('rule-matched-class', 'custom-match');
-			await waitFor(() => {
-				const rule = element.querySelector('[data-pattern]');
-				expect(rule.classList.contains('custom-match')).toBe(true);
-				expect(rule.classList.contains('validation-matched')).toBe(
-					false,
-				);
-			});
-		});
-
-		it('should throttle input-triggered validation and use latest value', () => {
-			vi.useFakeTimers();
-
-			try {
-				element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-				element.setAttribute('each-delay', '0');
-				element.setAttribute('input-throttle', '100');
-				element.disconnectedCallback();
-				element.connectedCallback();
-
-				const rule = element.querySelector('[data-pattern]');
-
-				input.value = 'abc';
-				input.dispatchEvent(new Event('input'));
-
-				input.value = 'ABC';
-				input.dispatchEvent(new Event('input'));
-
-				expect(rule.classList.contains('validation-matched')).toBe(
-					false,
-				);
-				expect(rule.classList.contains('validation-unmatched')).toBe(
-					false,
-				);
-
-				vi.advanceTimersByTime(100);
-
-				expect(rule.classList.contains('validation-matched')).toBe(
-					true,
-				);
-				expect(rule.classList.contains('validation-unmatched')).toBe(
-					false,
-				);
-			} finally {
-				vi.useRealTimers();
-			}
-		});
-
-		it('should not throttle non-input trigger events', () => {
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-			element.setAttribute('trigger-event', 'change');
-			element.setAttribute('input-throttle', '1000');
-			element.setAttribute('each-delay', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
-
-			const rule = element.querySelector('[data-pattern]');
-			input.value = 'ABC';
-			input.dispatchEvent(new Event('change'));
-
-			expect(rule.classList.contains('validation-matched')).toBe(true);
-			expect(rule.classList.contains('validation-unmatched')).toBe(false);
-		});
-	});
-
-	describe('public API', () => {
-		beforeEach(() => {
-			element.innerHTML = `
+      element.setAttribute('each-delay', '0');
+
+      // Trigger connectedCallback again to pick up new rules
+      element.disconnectedCallback();
+      element.connectedCallback();
+    });
+
+    it('should find all validation rules', () => {
+      expect(element._rules.length).toBe(3);
+    });
+
+    it('should not force role="listitem" on rule elements', () => {
+      const rules = element.querySelectorAll('[data-pattern]');
+      rules.forEach((rule) => {
+        expect(rule.hasAttribute('role')).toBe(false);
+      });
+    });
+
+    it('should set aria-atomic on rule elements (not aria-live)', () => {
+      const rules = element.querySelectorAll('[data-pattern]');
+      rules.forEach((rule) => {
+        expect(rule.getAttribute('aria-atomic')).toBe('true');
+        expect(rule.hasAttribute('aria-live')).toBe(false);
+      });
+    });
+
+    it('should validate input value against rules', async () => {
+      input.value = 'Test123';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        const rules = element.querySelectorAll('[data-pattern]');
+        expect(rules[0].classList.contains('validation-matched')).toBe(
+          true,
+        );
+        expect(rules[1].classList.contains('validation-matched')).toBe(
+          true,
+        );
+        expect(rules[2].classList.contains('validation-matched')).toBe(
+          true,
+        );
+      });
+    });
+
+    it('should mark unmatched rules', async () => {
+      input.value = 'test'; // Only lowercase
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        const rules = element.querySelectorAll('[data-pattern]');
+        expect(
+          rules[0].classList.contains('validation-unmatched'),
+        ).toBe(true);
+        expect(rules[1].classList.contains('validation-matched')).toBe(
+          true,
+        );
+        expect(
+          rules[2].classList.contains('validation-unmatched'),
+        ).toBe(true);
+      });
+    });
+
+    it('should add validation classes to the input field', async () => {
+      input.value = 'Test123';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(input.classList.contains('validation-valid')).toBe(true);
+        expect(input.classList.contains('validation-invalid')).toBe(
+          false,
+        );
+      });
+    });
+
+    it('should update field custom validity', async () => {
+      input.value = 'test'; // Invalid
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(input.validationMessage).toBeTruthy();
+      });
+
+      input.value = 'Test123'; // Valid
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(input.validationMessage).toBe('');
+      });
+    });
+
+    it('should replace all placeholders in validation-message template', async () => {
+      element.setAttribute(
+        'validation-message',
+        'Matched {matched}/{matched} of {total}/{total}',
+      );
+      element.setAttribute('each-delay', '0');
+      element.setAttribute('input-throttle', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      input.value = 'test';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(input.validationMessage).toBe('Matched 1/1 of 3/3');
+      });
+    });
+
+    it('should fire validation event', () => {
+      return new Promise((resolve) => {
+        element.addEventListener(
+          'form-validation-list:validated',
+          (e) => {
+            expect(e.detail.isValid).toBeDefined();
+            expect(e.detail.matchedRules).toBeDefined();
+            expect(e.detail.totalRules).toBe(3);
+            expect(e.detail.field).toBe(input);
+            resolve();
+          },
+        );
+
+        input.value = 'Test123';
+        input.dispatchEvent(new Event('input'));
+      });
+    });
+
+    it('should create a live region with aria-live and aria-atomic', () => {
+      const liveRegion = document.querySelector(
+        '.form-validation-list-live-region',
+      );
+      expect(liveRegion).toBeTruthy();
+      expect(liveRegion.getAttribute('aria-live')).toBe('polite');
+      expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
+    });
+
+    it('should update the live region with the announcement after validation', async () => {
+      element.setAttribute('each-delay', '0');
+      element.setAttribute('input-throttle', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      input.value = 'Test123';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        const liveRegion = document.querySelector(
+          '.form-validation-list-live-region',
+        );
+        expect(liveRegion.textContent).toContain('3');
+      });
+    });
+
+    it('should replace all matched and total placeholders in announcement', async () => {
+      element.setAttribute(
+        'announcement',
+        'Matched {matched}/{matched} of {total}/{total}',
+      );
+      element.setAttribute('each-delay', '0');
+      element.setAttribute('input-throttle', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      input.value = 'Test123';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        const liveRegion = document.querySelector(
+          '.form-validation-list-live-region',
+        );
+        expect(liveRegion.textContent).toBe('Matched 3/3 of 3/3');
+      });
+    });
+
+    it('should suspend aria-describedby on input and restore on blur', () => {
+      vi.useFakeTimers();
+
+      try {
+        element.setAttribute('each-delay', '0');
+        element.setAttribute('input-throttle', '0');
+        element.disconnectedCallback();
+        element.connectedCallback();
+
+        const listId = element.id;
+        expect(input.getAttribute('aria-describedby')).toContain(
+          listId,
+        );
+
+        input.value = 'A';
+        input.dispatchEvent(new Event('input'));
+        const describedByDuringTyping =
+          input.getAttribute('aria-describedby');
+        expect(
+          describedByDuringTyping === null ||
+          !describedByDuringTyping.includes(listId),
+        ).toBe(true);
+
+        input.dispatchEvent(new Event('blur'));
+        const describedByAfterBlur =
+          input.getAttribute('aria-describedby');
+        expect(
+          describedByAfterBlur === null ||
+          !describedByAfterBlur.includes(listId),
+        ).toBe(true);
+
+        vi.advanceTimersByTime(200);
+        expect(input.getAttribute('aria-describedby')).toContain(
+          listId,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should toggle has-value class based on field content', async () => {
+      element.setAttribute('each-delay', '0');
+      element.setAttribute('input-throttle', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      expect(element.classList.contains('has-value')).toBe(false);
+
+      input.value = 'A';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(element.classList.contains('has-value')).toBe(true);
+      });
+
+      input.value = '';
+      input.dispatchEvent(new Event('input'));
+
+      await waitFor(() => {
+        expect(element.classList.contains('has-value')).toBe(false);
+      });
+    });
+  });
+
+  describe('configuration attributes', () => {
+    it('should use default trigger event', () => {
+      expect(element.triggerEvent).toBe('input');
+    });
+
+    it('should allow custom trigger event', () => {
+      element.setAttribute('trigger-event', 'blur');
+      expect(element.triggerEvent).toBe('blur');
+    });
+
+    it('should use default each-delay', () => {
+      expect(element.eachDelay).toBe(150);
+    });
+
+    it('should use default input-throttle', () => {
+      expect(element.inputThrottle).toBe(250);
+    });
+
+    it('should allow custom input-throttle', () => {
+      element.setAttribute('input-throttle', '40');
+      expect(element.inputThrottle).toBe(40);
+    });
+
+    it('should allow custom each-delay', () => {
+      element.setAttribute('each-delay', '200');
+      expect(element.eachDelay).toBe(200);
+    });
+
+    it('should use default class names', () => {
+      expect(element.fieldInvalidClass).toBe('validation-invalid');
+      expect(element.fieldValidClass).toBe('validation-valid');
+      expect(element.ruleUnmatchedClass).toBe('validation-unmatched');
+      expect(element.ruleMatchedClass).toBe('validation-matched');
+    });
+
+    it('should use default icon alt text', () => {
+      expect(element.ruleMatchedAlt).toBe('Criteria met');
+      expect(element.ruleUnmatchedAlt).toBe('Criteria not met');
+    });
+
+    it('should allow custom icon alt text', () => {
+      element.setAttribute('rule-matched-alt', 'Met');
+      element.setAttribute('rule-unmatched-alt', 'Not met');
+      expect(element.ruleMatchedAlt).toBe('Met');
+      expect(element.ruleUnmatchedAlt).toBe('Not met');
+    });
+
+    it('should use default announcement template', () => {
+      expect(element.announcement).toBe(
+        'Criteria met: {matched} of {total}',
+      );
+    });
+
+    it('should allow custom announcement template', () => {
+      element.setAttribute('announcement', '{matched}/{total} ok');
+      expect(element.announcement).toBe('{matched}/{total} ok');
+    });
+
+    it('should allow custom icons via attribute', () => {
+      element.setAttribute('rule-matched-icon', '✅');
+      element.setAttribute('rule-unmatched-icon', '❌');
+      expect(element.ruleMatchedIcon).toBe('✅');
+      expect(element.ruleUnmatchedIcon).toBe('❌');
+    });
+
+    it('should allow custom class names', () => {
+      element.setAttribute('field-invalid-class', 'custom-invalid');
+      element.setAttribute('field-valid-class', 'custom-valid');
+      element.setAttribute('rule-unmatched-class', 'custom-unmatched');
+      element.setAttribute('rule-matched-class', 'custom-matched');
+
+      expect(element.fieldInvalidClass).toBe('custom-invalid');
+      expect(element.fieldValidClass).toBe('custom-valid');
+      expect(element.ruleUnmatchedClass).toBe('custom-unmatched');
+      expect(element.ruleMatchedClass).toBe('custom-matched');
+    });
+
+    it('should rebind validation handler when trigger-event changes', async () => {
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+      element.setAttribute('each-delay', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      element.setAttribute('trigger-event', 'blur');
+      input.value = 'TEST';
+      input.dispatchEvent(new Event('blur'));
+
+      await waitFor(() => {
+        expect(
+          element
+            .querySelector('[data-pattern]')
+            .classList.contains('validation-matched'),
+        ).toBe(true);
+      });
+    });
+
+    it('should refresh field classes when field-valid-class changes', async () => {
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+      element.setAttribute('each-delay', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      input.value = 'TEST';
+      input.dispatchEvent(new Event('input'));
+      await waitFor(() => {
+        expect(input.classList.contains('validation-valid')).toBe(true);
+      });
+
+      element.setAttribute('field-valid-class', 'custom-good');
+      await waitFor(() => {
+        expect(input.classList.contains('custom-good')).toBe(true);
+        expect(input.classList.contains('validation-valid')).toBe(
+          false,
+        );
+      });
+    });
+
+    it('should refresh rule classes when rule-matched-class changes', async () => {
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+      element.setAttribute('each-delay', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      input.value = 'TEST';
+      input.dispatchEvent(new Event('input'));
+      await waitFor(() => {
+        expect(
+          element
+            .querySelector('[data-pattern]')
+            .classList.contains('validation-matched'),
+        ).toBe(true);
+      });
+
+      element.setAttribute('rule-matched-class', 'custom-match');
+      await waitFor(() => {
+        const rule = element.querySelector('[data-pattern]');
+        expect(rule.classList.contains('custom-match')).toBe(true);
+        expect(rule.classList.contains('validation-matched')).toBe(
+          false,
+        );
+      });
+    });
+
+    it('should throttle input-triggered validation and use latest value', () => {
+      vi.useFakeTimers();
+
+      try {
+        element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+        element.setAttribute('each-delay', '0');
+        element.setAttribute('input-throttle', '100');
+        element.disconnectedCallback();
+        element.connectedCallback();
+
+        const rule = element.querySelector('[data-pattern]');
+
+        input.value = 'abc';
+        input.dispatchEvent(new Event('input'));
+
+        input.value = 'ABC';
+        input.dispatchEvent(new Event('input'));
+
+        expect(rule.classList.contains('validation-matched')).toBe(
+          false,
+        );
+        expect(rule.classList.contains('validation-unmatched')).toBe(
+          false,
+        );
+
+        vi.advanceTimersByTime(100);
+
+        expect(rule.classList.contains('validation-matched')).toBe(
+          true,
+        );
+        expect(rule.classList.contains('validation-unmatched')).toBe(
+          false,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should not throttle blur trigger events', () => {
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+      element.setAttribute('trigger-event', 'blur');
+      element.setAttribute('input-throttle', '1000');
+      element.setAttribute('each-delay', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
+
+      const rule = element.querySelector('[data-pattern]');
+      input.value = 'ABC';
+      input.dispatchEvent(new Event('blur'));
+
+      expect(rule.classList.contains('validation-matched')).toBe(true);
+      expect(rule.classList.contains('validation-unmatched')).toBe(false);
+    });
+  });
+
+  describe('public API', () => {
+    beforeEach(() => {
+      element.innerHTML = `
 				<ul>
 					<li data-pattern="[A-Z]+">Capital letter</li>
 					<li data-pattern="[0-9]+">Number</li>
 				</ul>
 			`;
-			element.disconnectedCallback();
-			element.connectedCallback();
-		});
+      element.disconnectedCallback();
+      element.connectedCallback();
+    });
 
-		it('should provide validate() method', () => {
-			expect(typeof element.validate).toBe('function');
-		});
+    it('should provide validate() method', () => {
+      expect(typeof element.validate).toBe('function');
+    });
 
-		it('validate() should return validation state', () => {
-			input.value = 'Test123';
-			const isValid = element.validate();
-			expect(typeof isValid).toBe('boolean');
-		});
+    it('validate() should return validation state', () => {
+      input.value = 'Test123';
+      const isValid = element.validate();
+      expect(typeof isValid).toBe('boolean');
+    });
 
-		it('should provide isValid getter', () => {
-			input.value = 'Test123';
-			element.validate();
-			expect(typeof element.isValid).toBe('boolean');
-		});
-	});
+    it('should provide isValid getter', () => {
+      input.value = 'Test123';
+      element.validate();
+      expect(typeof element.isValid).toBe('boolean');
+    });
+  });
 
-	describe('cleanup', () => {
-		it('should remove only this id from aria-describedby when disconnected', () => {
-			input.setAttribute('aria-describedby', 'existing-id');
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-			element.disconnectedCallback();
-			element.connectedCallback();
+  describe('cleanup', () => {
+    it('should remove only this id from aria-describedby when disconnected', () => {
+      input.setAttribute('aria-describedby', 'existing-id');
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+      element.disconnectedCallback();
+      element.connectedCallback();
 
-			const listId = element.id;
-			expect(input.getAttribute('aria-describedby')).toContain(
-				'existing-id',
-			);
-			expect(input.getAttribute('aria-describedby')).toContain(listId);
+      const listId = element.id;
+      expect(input.getAttribute('aria-describedby')).toContain(
+        'existing-id',
+      );
+      expect(input.getAttribute('aria-describedby')).toContain(listId);
 
-			element.disconnectedCallback();
+      element.disconnectedCallback();
 
-			expect(input.getAttribute('aria-describedby')).toBe('existing-id');
-		});
+      expect(input.getAttribute('aria-describedby')).toBe('existing-id');
+    });
 
-		it('should cleanup when disconnected', async () => {
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-			element.setAttribute('each-delay', '0');
-			element.disconnectedCallback();
-			element.connectedCallback();
+    it('should cleanup when disconnected', async () => {
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+      element.setAttribute('each-delay', '0');
+      element.disconnectedCallback();
+      element.connectedCallback();
 
-			input.value = 'Test';
-			input.dispatchEvent(new Event('input'));
-			await waitFor(() => {
-				expect(input.classList.contains('validation-valid')).toBe(true);
-			});
+      input.value = 'Test';
+      input.dispatchEvent(new Event('input'));
+      await waitFor(() => {
+        expect(input.classList.contains('validation-valid')).toBe(true);
+      });
 
-			element.disconnectedCallback();
+      element.disconnectedCallback();
 
-			// Field should not have validation classes after cleanup
-			expect(input.classList.contains('validation-valid')).toBe(false);
-			expect(input.classList.contains('validation-invalid')).toBe(false);
-		});
+      // Field should not have validation classes after cleanup
+      expect(input.classList.contains('validation-valid')).toBe(false);
+      expect(input.classList.contains('validation-invalid')).toBe(false);
+    });
 
-		it('should cleanup when for attribute changes', () => {
-			const nextInput = document.createElement('input');
-			nextInput.type = 'text';
-			nextInput.id = 'next-input';
-			document.body.appendChild(nextInput);
+    it('should cleanup when for attribute changes', () => {
+      const nextInput = document.createElement('input');
+      nextInput.type = 'text';
+      nextInput.id = 'next-input';
+      document.body.appendChild(nextInput);
 
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-			element.disconnectedCallback();
-			element.connectedCallback();
+      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+      element.disconnectedCallback();
+      element.connectedCallback();
 
-			const oldField = element._field;
-			oldField.setAttribute('aria-describedby', 'existing-id');
-			element._setupAccessibility();
+      const oldField = element._field;
+      oldField.setAttribute('aria-describedby', 'existing-id');
+      element._setupAccessibility();
 
-			element.setAttribute('for', 'next-input');
+      element.setAttribute('for', 'next-input');
 
-			expect(element._field).not.toBe(oldField);
-			expect(oldField.getAttribute('aria-describedby')).toBe(
-				'existing-id',
-			);
-		});
-	});
+      expect(element._field).not.toBe(oldField);
+      expect(oldField.getAttribute('aria-describedby')).toBe(
+        'existing-id',
+      );
+    });
+  });
 });

--- a/test/form-validation-list.test.js
+++ b/test/form-validation-list.test.js
@@ -485,13 +485,21 @@ describe('FormValidationListElement', () => {
 				input.value = 'ABC';
 				input.dispatchEvent(new Event('input'));
 
-				expect(rule.classList.contains('validation-matched')).toBe(false);
-				expect(rule.classList.contains('validation-unmatched')).toBe(false);
+				expect(rule.classList.contains('validation-matched')).toBe(
+					false,
+				);
+				expect(rule.classList.contains('validation-unmatched')).toBe(
+					false,
+				);
 
 				vi.advanceTimersByTime(100);
 
-				expect(rule.classList.contains('validation-matched')).toBe(true);
-				expect(rule.classList.contains('validation-unmatched')).toBe(false);
+				expect(rule.classList.contains('validation-matched')).toBe(
+					true,
+				);
+				expect(rule.classList.contains('validation-unmatched')).toBe(
+					false,
+				);
 			} finally {
 				vi.useRealTimers();
 			}

--- a/test/form-validation-list.test.js
+++ b/test/form-validation-list.test.js
@@ -470,29 +470,31 @@ describe('FormValidationListElement', () => {
 		it('should throttle input-triggered validation and use latest value', () => {
 			vi.useFakeTimers();
 
-			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-			element.setAttribute('each-delay', '0');
-			element.setAttribute('input-throttle', '100');
-			element.disconnectedCallback();
-			element.connectedCallback();
+			try {
+				element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+				element.setAttribute('each-delay', '0');
+				element.setAttribute('input-throttle', '100');
+				element.disconnectedCallback();
+				element.connectedCallback();
 
-			const rule = element.querySelector('[data-pattern]');
+				const rule = element.querySelector('[data-pattern]');
 
-			input.value = 'abc';
-			input.dispatchEvent(new Event('input'));
+				input.value = 'abc';
+				input.dispatchEvent(new Event('input'));
 
-			input.value = 'ABC';
-			input.dispatchEvent(new Event('input'));
+				input.value = 'ABC';
+				input.dispatchEvent(new Event('input'));
 
-			expect(rule.classList.contains('validation-matched')).toBe(false);
-			expect(rule.classList.contains('validation-unmatched')).toBe(false);
+				expect(rule.classList.contains('validation-matched')).toBe(false);
+				expect(rule.classList.contains('validation-unmatched')).toBe(false);
 
-			vi.advanceTimersByTime(100);
+				vi.advanceTimersByTime(100);
 
-			expect(rule.classList.contains('validation-matched')).toBe(true);
-			expect(rule.classList.contains('validation-unmatched')).toBe(false);
-
-			vi.useRealTimers();
+				expect(rule.classList.contains('validation-matched')).toBe(true);
+				expect(rule.classList.contains('validation-unmatched')).toBe(false);
+			} finally {
+				vi.useRealTimers();
+			}
 		});
 
 		it('should not throttle non-input trigger events', () => {

--- a/test/form-validation-list.test.js
+++ b/test/form-validation-list.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { waitFor } from '@testing-library/dom';
 import { FormValidationListElement } from '../form-validation-list.js';
 
@@ -250,6 +250,15 @@ describe('FormValidationListElement', () => {
 			expect(element.eachDelay).toBe(150);
 		});
 
+		it('should use default input-throttle', () => {
+			expect(element.inputThrottle).toBe(250);
+		});
+
+		it('should allow custom input-throttle', () => {
+			element.setAttribute('input-throttle', '40');
+			expect(element.inputThrottle).toBe(40);
+		});
+
 		it('should allow custom each-delay', () => {
 			element.setAttribute('each-delay', '200');
 			expect(element.eachDelay).toBe(200);
@@ -338,6 +347,50 @@ describe('FormValidationListElement', () => {
 					false,
 				);
 			});
+		});
+
+		it('should throttle input-triggered validation and use latest value', () => {
+			vi.useFakeTimers();
+
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '100');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			const rule = element.querySelector('[data-pattern]');
+
+			input.value = 'abc';
+			input.dispatchEvent(new Event('input'));
+
+			input.value = 'ABC';
+			input.dispatchEvent(new Event('input'));
+
+			expect(rule.classList.contains('validation-matched')).toBe(false);
+			expect(rule.classList.contains('validation-unmatched')).toBe(false);
+
+			vi.advanceTimersByTime(100);
+
+			expect(rule.classList.contains('validation-matched')).toBe(true);
+			expect(rule.classList.contains('validation-unmatched')).toBe(false);
+
+			vi.useRealTimers();
+		});
+
+		it('should not throttle non-input trigger events', () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+			element.setAttribute('trigger-event', 'change');
+			element.setAttribute('input-throttle', '1000');
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			const rule = element.querySelector('[data-pattern]');
+			input.value = 'ABC';
+			input.dispatchEvent(new Event('change'));
+
+			expect(rule.classList.contains('validation-matched')).toBe(true);
+			expect(rule.classList.contains('validation-unmatched')).toBe(false);
 		});
 	});
 

--- a/test/form-validation-list.test.js
+++ b/test/form-validation-list.test.js
@@ -3,664 +3,664 @@ import { waitFor } from '@testing-library/dom';
 import { FormValidationListElement } from '../form-validation-list.js';
 
 describe('FormValidationListElement', () => {
-  let element;
-  let input;
+	let element;
+	let input;
 
-  beforeEach(() => {
-    // Create a test input field
-    input = document.createElement('input');
-    input.type = 'text';
-    input.id = 'test-input';
-    document.body.appendChild(input);
+	beforeEach(() => {
+		// Create a test input field
+		input = document.createElement('input');
+		input.type = 'text';
+		input.id = 'test-input';
+		document.body.appendChild(input);
 
-    // Create the validation list element
-    element = document.createElement('form-validation-list');
-    element.setAttribute('for', 'test-input');
-    document.body.appendChild(element);
-  });
+		// Create the validation list element
+		element = document.createElement('form-validation-list');
+		element.setAttribute('for', 'test-input');
+		document.body.appendChild(element);
+	});
 
-  afterEach(() => {
-    document.body.innerHTML = '';
-  });
+	afterEach(() => {
+		document.body.innerHTML = '';
+	});
 
-  it('should be defined', () => {
-    expect(customElements.get('form-validation-list')).toBe(
-      FormValidationListElement,
-    );
-  });
+	it('should be defined', () => {
+		expect(customElements.get('form-validation-list')).toBe(
+			FormValidationListElement,
+		);
+	});
 
-  it('should create an instance', () => {
-    expect(element).toBeInstanceOf(FormValidationListElement);
-    expect(element).toBeInstanceOf(HTMLElement);
-  });
+	it('should create an instance', () => {
+		expect(element).toBeInstanceOf(FormValidationListElement);
+		expect(element).toBeInstanceOf(HTMLElement);
+	});
 
-  it('should not have a shadow root (uses light DOM)', () => {
-    expect(element.shadowRoot).toBeFalsy();
-  });
+	it('should not have a shadow root (uses light DOM)', () => {
+		expect(element.shadowRoot).toBeFalsy();
+	});
 
-  it('should not force role="list" on host', () => {
-    expect(element.hasAttribute('role')).toBe(false);
-  });
+	it('should not force role="list" on host', () => {
+		expect(element.hasAttribute('role')).toBe(false);
+	});
 
-  it('should find the associated input field', () => {
-    expect(element._field).toBe(input);
-  });
+	it('should find the associated input field', () => {
+		expect(element._field).toBe(input);
+	});
 
-  it('should set up aria-describedby on the input field', () => {
-    // Need to add rules for the element to set up aria-describedby
-    element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
-    element.disconnectedCallback();
-    element.connectedCallback();
+	it('should set up aria-describedby on the input field', () => {
+		// Need to add rules for the element to set up aria-describedby
+		element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
+		element.disconnectedCallback();
+		element.connectedCallback();
 
-    const listId = element.querySelector('ul, ol').id;
-    const describedBy = input.getAttribute('aria-describedby');
-    expect(describedBy).toBeTruthy();
-    expect(describedBy).toContain(listId);
-  });
+		const listId = element.querySelector('ul, ol').id;
+		const describedBy = input.getAttribute('aria-describedby');
+		expect(describedBy).toBeTruthy();
+		expect(describedBy).toContain(listId);
+	});
 
-  it('should preserve existing aria-describedby values', () => {
-    // Clean up previous element
-    element.remove();
+	it('should preserve existing aria-describedby values', () => {
+		// Clean up previous element
+		element.remove();
 
-    // Set existing describedby
-    input.setAttribute('aria-describedby', 'existing-id');
+		// Set existing describedby
+		input.setAttribute('aria-describedby', 'existing-id');
 
-    // Create new element
-    element = document.createElement('form-validation-list');
-    element.setAttribute('for', 'test-input');
-    document.body.appendChild(element);
+		// Create new element
+		element = document.createElement('form-validation-list');
+		element.setAttribute('for', 'test-input');
+		document.body.appendChild(element);
 
-    element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
-    element.disconnectedCallback();
-    element.connectedCallback();
+		element.innerHTML = '<ul><li data-pattern="[A-Z]+">Capital</li></ul>';
+		element.disconnectedCallback();
+		element.connectedCallback();
 
-    const listId = element.querySelector('ul, ol').id;
-    const describedBy = input.getAttribute('aria-describedby');
-    expect(describedBy).toContain('existing-id');
-    expect(describedBy).toContain(listId);
-  });
+		const listId = element.querySelector('ul, ol').id;
+		const describedBy = input.getAttribute('aria-describedby');
+		expect(describedBy).toContain('existing-id');
+		expect(describedBy).toContain(listId);
+	});
 
-  describe('property reflection', () => {
-    it('should reflect fieldId property to the for attribute', () => {
-      const otherInput = document.createElement('input');
-      otherInput.id = 'other-input';
-      document.body.appendChild(otherInput);
+	describe('property reflection', () => {
+		it('should reflect fieldId property to the for attribute', () => {
+			const otherInput = document.createElement('input');
+			otherInput.id = 'other-input';
+			document.body.appendChild(otherInput);
 
-      const localElement = document.createElement('form-validation-list');
-      document.body.appendChild(localElement);
+			const localElement = document.createElement('form-validation-list');
+			document.body.appendChild(localElement);
 
-      localElement.fieldId = 'other-input';
-      expect(localElement.getAttribute('for')).toBe('other-input');
-    });
+			localElement.fieldId = 'other-input';
+			expect(localElement.getAttribute('for')).toBe('other-input');
+		});
 
-    it('should reflect triggerEvent property to the attribute', () => {
-      const localElement = document.createElement('form-validation-list');
-      localElement.triggerEvent = 'blur';
-      expect(localElement.getAttribute('trigger-event')).toBe('blur');
-    });
+		it('should reflect triggerEvent property to the attribute', () => {
+			const localElement = document.createElement('form-validation-list');
+			localElement.triggerEvent = 'blur';
+			expect(localElement.getAttribute('trigger-event')).toBe('blur');
+		});
 
-    it('should normalize unsupported trigger events to input', () => {
-      const localElement = document.createElement('form-validation-list');
-      localElement.triggerEvent = 'change';
-      expect(localElement.getAttribute('trigger-event')).toBe('input');
-      expect(localElement.triggerEvent).toBe('input');
-    });
+		it('should normalize unsupported trigger events to input', () => {
+			const localElement = document.createElement('form-validation-list');
+			localElement.triggerEvent = 'change';
+			expect(localElement.getAttribute('trigger-event')).toBe('input');
+			expect(localElement.triggerEvent).toBe('input');
+		});
 
-    it('should upgrade properties set before connecting', async () => {
-      const upgradeInput = document.createElement('input');
-      upgradeInput.id = 'upgrade-input';
-      document.body.appendChild(upgradeInput);
+		it('should upgrade properties set before connecting', async () => {
+			const upgradeInput = document.createElement('input');
+			upgradeInput.id = 'upgrade-input';
+			document.body.appendChild(upgradeInput);
 
-      const localElement = document.createElement('form-validation-list');
-      localElement.fieldId = 'upgrade-input';
-      localElement.triggerEvent = 'blur';
-      localElement.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-      localElement.setAttribute('each-delay', '0');
-      document.body.appendChild(localElement);
+			const localElement = document.createElement('form-validation-list');
+			localElement.fieldId = 'upgrade-input';
+			localElement.triggerEvent = 'blur';
+			localElement.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+			localElement.setAttribute('each-delay', '0');
+			document.body.appendChild(localElement);
 
-      upgradeInput.value = 'TEST';
-      upgradeInput.dispatchEvent(new Event('blur'));
+			upgradeInput.value = 'TEST';
+			upgradeInput.dispatchEvent(new Event('blur'));
 
-      await waitFor(() => {
-        expect(
-          localElement
-            .querySelector('[data-pattern]')
-            .classList.contains('validation-matched'),
-        ).toBe(true);
-      });
-    });
-  });
+			await waitFor(() => {
+				expect(
+					localElement
+						.querySelector('[data-pattern]')
+						.classList.contains('validation-matched'),
+				).toBe(true);
+			});
+		});
+	});
 
-  describe('validation rules', () => {
-    beforeEach(() => {
-      element.innerHTML = `
+	describe('validation rules', () => {
+		beforeEach(() => {
+			element.innerHTML = `
 				<ul>
 					<li data-pattern="[A-Z]+">At least one capital letter</li>
 					<li data-pattern="[a-z]+">At least one lowercase letter</li>
 					<li data-pattern="[0-9]+">At least one number</li>
 				</ul>
 			`;
-      element.setAttribute('each-delay', '0');
-
-      // Trigger connectedCallback again to pick up new rules
-      element.disconnectedCallback();
-      element.connectedCallback();
-    });
-
-    it('should find all validation rules', () => {
-      expect(element._rules.length).toBe(3);
-    });
-
-    it('should not force role="listitem" on rule elements', () => {
-      const rules = element.querySelectorAll('[data-pattern]');
-      rules.forEach((rule) => {
-        expect(rule.hasAttribute('role')).toBe(false);
-      });
-    });
-
-    it('should set aria-atomic on rule elements (not aria-live)', () => {
-      const rules = element.querySelectorAll('[data-pattern]');
-      rules.forEach((rule) => {
-        expect(rule.getAttribute('aria-atomic')).toBe('true');
-        expect(rule.hasAttribute('aria-live')).toBe(false);
-      });
-    });
-
-    it('should validate input value against rules', async () => {
-      input.value = 'Test123';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        const rules = element.querySelectorAll('[data-pattern]');
-        expect(rules[0].classList.contains('validation-matched')).toBe(
-          true,
-        );
-        expect(rules[1].classList.contains('validation-matched')).toBe(
-          true,
-        );
-        expect(rules[2].classList.contains('validation-matched')).toBe(
-          true,
-        );
-      });
-    });
-
-    it('should mark unmatched rules', async () => {
-      input.value = 'test'; // Only lowercase
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        const rules = element.querySelectorAll('[data-pattern]');
-        expect(
-          rules[0].classList.contains('validation-unmatched'),
-        ).toBe(true);
-        expect(rules[1].classList.contains('validation-matched')).toBe(
-          true,
-        );
-        expect(
-          rules[2].classList.contains('validation-unmatched'),
-        ).toBe(true);
-      });
-    });
-
-    it('should add validation classes to the input field', async () => {
-      input.value = 'Test123';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(input.classList.contains('validation-valid')).toBe(true);
-        expect(input.classList.contains('validation-invalid')).toBe(
-          false,
-        );
-      });
-    });
-
-    it('should update field custom validity', async () => {
-      input.value = 'test'; // Invalid
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(input.validationMessage).toBeTruthy();
-      });
-
-      input.value = 'Test123'; // Valid
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(input.validationMessage).toBe('');
-      });
-    });
-
-    it('should replace all placeholders in validation-message template', async () => {
-      element.setAttribute(
-        'validation-message',
-        'Matched {matched}/{matched} of {total}/{total}',
-      );
-      element.setAttribute('each-delay', '0');
-      element.setAttribute('input-throttle', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      input.value = 'test';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(input.validationMessage).toBe('Matched 1/1 of 3/3');
-      });
-    });
-
-    it('should fire validation event', () => {
-      return new Promise((resolve) => {
-        element.addEventListener(
-          'form-validation-list:validated',
-          (e) => {
-            expect(e.detail.isValid).toBeDefined();
-            expect(e.detail.matchedRules).toBeDefined();
-            expect(e.detail.totalRules).toBe(3);
-            expect(e.detail.field).toBe(input);
-            resolve();
-          },
-        );
-
-        input.value = 'Test123';
-        input.dispatchEvent(new Event('input'));
-      });
-    });
-
-    it('should create a live region with aria-live and aria-atomic', () => {
-      const liveRegion = document.querySelector(
-        '.form-validation-list-live-region',
-      );
-      expect(liveRegion).toBeTruthy();
-      expect(liveRegion.getAttribute('aria-live')).toBe('polite');
-      expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
-    });
-
-    it('should update the live region with the announcement after validation', async () => {
-      element.setAttribute('each-delay', '0');
-      element.setAttribute('input-throttle', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      input.value = 'Test123';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        const liveRegion = document.querySelector(
-          '.form-validation-list-live-region',
-        );
-        expect(liveRegion.textContent).toContain('3');
-      });
-    });
-
-    it('should replace all matched and total placeholders in announcement', async () => {
-      element.setAttribute(
-        'announcement',
-        'Matched {matched}/{matched} of {total}/{total}',
-      );
-      element.setAttribute('each-delay', '0');
-      element.setAttribute('input-throttle', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      input.value = 'Test123';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        const liveRegion = document.querySelector(
-          '.form-validation-list-live-region',
-        );
-        expect(liveRegion.textContent).toBe('Matched 3/3 of 3/3');
-      });
-    });
-
-    it('should suspend aria-describedby on input and restore on blur', () => {
-      vi.useFakeTimers();
-
-      try {
-        element.setAttribute('each-delay', '0');
-        element.setAttribute('input-throttle', '0');
-        element.disconnectedCallback();
-        element.connectedCallback();
-
-        const listId = element.querySelector('ul, ol').id;
-        expect(input.getAttribute('aria-describedby')).toContain(
-          listId,
-        );
-
-        input.value = 'A';
-        input.dispatchEvent(new Event('input'));
-        const describedByDuringTyping =
-          input.getAttribute('aria-describedby');
-        expect(
-          describedByDuringTyping === null ||
-          !describedByDuringTyping.includes(listId),
-        ).toBe(true);
-
-        input.dispatchEvent(new Event('blur'));
-        const describedByAfterBlur =
-          input.getAttribute('aria-describedby');
-        expect(
-          describedByAfterBlur === null ||
-          !describedByAfterBlur.includes(listId),
-        ).toBe(true);
-
-        vi.advanceTimersByTime(200);
-        expect(input.getAttribute('aria-describedby')).toContain(
-          listId,
-        );
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it('should toggle has-value class based on field content', async () => {
-      element.setAttribute('each-delay', '0');
-      element.setAttribute('input-throttle', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      expect(element.classList.contains('has-value')).toBe(false);
-
-      input.value = 'A';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(element.classList.contains('has-value')).toBe(true);
-      });
-
-      input.value = '';
-      input.dispatchEvent(new Event('input'));
-
-      await waitFor(() => {
-        expect(element.classList.contains('has-value')).toBe(false);
-      });
-    });
-  });
-
-  describe('configuration attributes', () => {
-    it('should use default trigger event', () => {
-      expect(element.triggerEvent).toBe('input');
-    });
-
-    it('should allow custom trigger event', () => {
-      element.setAttribute('trigger-event', 'blur');
-      expect(element.triggerEvent).toBe('blur');
-    });
-
-    it('should use default each-delay', () => {
-      expect(element.eachDelay).toBe(150);
-    });
-
-    it('should use default input-throttle', () => {
-      expect(element.inputThrottle).toBe(250);
-    });
-
-    it('should allow custom input-throttle', () => {
-      element.setAttribute('input-throttle', '40');
-      expect(element.inputThrottle).toBe(40);
-    });
-
-    it('should allow custom each-delay', () => {
-      element.setAttribute('each-delay', '200');
-      expect(element.eachDelay).toBe(200);
-    });
-
-    it('should use default class names', () => {
-      expect(element.fieldInvalidClass).toBe('validation-invalid');
-      expect(element.fieldValidClass).toBe('validation-valid');
-      expect(element.ruleUnmatchedClass).toBe('validation-unmatched');
-      expect(element.ruleMatchedClass).toBe('validation-matched');
-    });
-
-    it('should use default icon alt text', () => {
-      expect(element.ruleMatchedAlt).toBe('Criteria met');
-      expect(element.ruleUnmatchedAlt).toBe('Criteria not met');
-    });
-
-    it('should allow custom icon alt text', () => {
-      element.setAttribute('rule-matched-alt', 'Met');
-      element.setAttribute('rule-unmatched-alt', 'Not met');
-      expect(element.ruleMatchedAlt).toBe('Met');
-      expect(element.ruleUnmatchedAlt).toBe('Not met');
-    });
-
-    it('should use default announcement template', () => {
-      expect(element.announcement).toBe(
-        'Criteria met: {matched} of {total}',
-      );
-    });
-
-    it('should allow custom announcement template', () => {
-      element.setAttribute('announcement', '{matched}/{total} ok');
-      expect(element.announcement).toBe('{matched}/{total} ok');
-    });
-
-    it('should allow custom icons via attribute', () => {
-      element.setAttribute('rule-matched-icon', '✅');
-      element.setAttribute('rule-unmatched-icon', '❌');
-      expect(element.ruleMatchedIcon).toBe('✅');
-      expect(element.ruleUnmatchedIcon).toBe('❌');
-    });
-
-    it('should allow custom class names', () => {
-      element.setAttribute('field-invalid-class', 'custom-invalid');
-      element.setAttribute('field-valid-class', 'custom-valid');
-      element.setAttribute('rule-unmatched-class', 'custom-unmatched');
-      element.setAttribute('rule-matched-class', 'custom-matched');
-
-      expect(element.fieldInvalidClass).toBe('custom-invalid');
-      expect(element.fieldValidClass).toBe('custom-valid');
-      expect(element.ruleUnmatchedClass).toBe('custom-unmatched');
-      expect(element.ruleMatchedClass).toBe('custom-matched');
-    });
-
-    it('should rebind validation handler when trigger-event changes', async () => {
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-      element.setAttribute('each-delay', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      element.setAttribute('trigger-event', 'blur');
-      input.value = 'TEST';
-      input.dispatchEvent(new Event('blur'));
-
-      await waitFor(() => {
-        expect(
-          element
-            .querySelector('[data-pattern]')
-            .classList.contains('validation-matched'),
-        ).toBe(true);
-      });
-    });
-
-    it('should refresh field classes when field-valid-class changes', async () => {
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-      element.setAttribute('each-delay', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      input.value = 'TEST';
-      input.dispatchEvent(new Event('input'));
-      await waitFor(() => {
-        expect(input.classList.contains('validation-valid')).toBe(true);
-      });
-
-      element.setAttribute('field-valid-class', 'custom-good');
-      await waitFor(() => {
-        expect(input.classList.contains('custom-good')).toBe(true);
-        expect(input.classList.contains('validation-valid')).toBe(
-          false,
-        );
-      });
-    });
-
-    it('should refresh rule classes when rule-matched-class changes', async () => {
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-      element.setAttribute('each-delay', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      input.value = 'TEST';
-      input.dispatchEvent(new Event('input'));
-      await waitFor(() => {
-        expect(
-          element
-            .querySelector('[data-pattern]')
-            .classList.contains('validation-matched'),
-        ).toBe(true);
-      });
-
-      element.setAttribute('rule-matched-class', 'custom-match');
-      await waitFor(() => {
-        const rule = element.querySelector('[data-pattern]');
-        expect(rule.classList.contains('custom-match')).toBe(true);
-        expect(rule.classList.contains('validation-matched')).toBe(
-          false,
-        );
-      });
-    });
-
-    it('should throttle input-triggered validation and use latest value', () => {
-      vi.useFakeTimers();
-
-      try {
-        element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-        element.setAttribute('each-delay', '0');
-        element.setAttribute('input-throttle', '100');
-        element.disconnectedCallback();
-        element.connectedCallback();
-
-        const rule = element.querySelector('[data-pattern]');
-
-        input.value = 'abc';
-        input.dispatchEvent(new Event('input'));
-
-        input.value = 'ABC';
-        input.dispatchEvent(new Event('input'));
-
-        expect(rule.classList.contains('validation-matched')).toBe(
-          false,
-        );
-        expect(rule.classList.contains('validation-unmatched')).toBe(
-          false,
-        );
-
-        vi.advanceTimersByTime(100);
-
-        expect(rule.classList.contains('validation-matched')).toBe(
-          true,
-        );
-        expect(rule.classList.contains('validation-unmatched')).toBe(
-          false,
-        );
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it('should not throttle blur trigger events', () => {
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
-      element.setAttribute('trigger-event', 'blur');
-      element.setAttribute('input-throttle', '1000');
-      element.setAttribute('each-delay', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
-
-      const rule = element.querySelector('[data-pattern]');
-      input.value = 'ABC';
-      input.dispatchEvent(new Event('blur'));
-
-      expect(rule.classList.contains('validation-matched')).toBe(true);
-      expect(rule.classList.contains('validation-unmatched')).toBe(false);
-    });
-  });
-
-  describe('public API', () => {
-    beforeEach(() => {
-      element.innerHTML = `
+			element.setAttribute('each-delay', '0');
+
+			// Trigger connectedCallback again to pick up new rules
+			element.disconnectedCallback();
+			element.connectedCallback();
+		});
+
+		it('should find all validation rules', () => {
+			expect(element._rules.length).toBe(3);
+		});
+
+		it('should not force role="listitem" on rule elements', () => {
+			const rules = element.querySelectorAll('[data-pattern]');
+			rules.forEach((rule) => {
+				expect(rule.hasAttribute('role')).toBe(false);
+			});
+		});
+
+		it('should set aria-atomic on rule elements (not aria-live)', () => {
+			const rules = element.querySelectorAll('[data-pattern]');
+			rules.forEach((rule) => {
+				expect(rule.getAttribute('aria-atomic')).toBe('true');
+				expect(rule.hasAttribute('aria-live')).toBe(false);
+			});
+		});
+
+		it('should validate input value against rules', async () => {
+			input.value = 'Test123';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				const rules = element.querySelectorAll('[data-pattern]');
+				expect(rules[0].classList.contains('validation-matched')).toBe(
+					true,
+				);
+				expect(rules[1].classList.contains('validation-matched')).toBe(
+					true,
+				);
+				expect(rules[2].classList.contains('validation-matched')).toBe(
+					true,
+				);
+			});
+		});
+
+		it('should mark unmatched rules', async () => {
+			input.value = 'test'; // Only lowercase
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				const rules = element.querySelectorAll('[data-pattern]');
+				expect(
+					rules[0].classList.contains('validation-unmatched'),
+				).toBe(true);
+				expect(rules[1].classList.contains('validation-matched')).toBe(
+					true,
+				);
+				expect(
+					rules[2].classList.contains('validation-unmatched'),
+				).toBe(true);
+			});
+		});
+
+		it('should add validation classes to the input field', async () => {
+			input.value = 'Test123';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(input.classList.contains('validation-valid')).toBe(true);
+				expect(input.classList.contains('validation-invalid')).toBe(
+					false,
+				);
+			});
+		});
+
+		it('should update field custom validity', async () => {
+			input.value = 'test'; // Invalid
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(input.validationMessage).toBeTruthy();
+			});
+
+			input.value = 'Test123'; // Valid
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(input.validationMessage).toBe('');
+			});
+		});
+
+		it('should replace all placeholders in validation-message template', async () => {
+			element.setAttribute(
+				'validation-message',
+				'Matched {matched}/{matched} of {total}/{total}',
+			);
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'test';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(input.validationMessage).toBe('Matched 1/1 of 3/3');
+			});
+		});
+
+		it('should fire validation event', () => {
+			return new Promise((resolve) => {
+				element.addEventListener(
+					'form-validation-list:validated',
+					(e) => {
+						expect(e.detail.isValid).toBeDefined();
+						expect(e.detail.matchedRules).toBeDefined();
+						expect(e.detail.totalRules).toBe(3);
+						expect(e.detail.field).toBe(input);
+						resolve();
+					},
+				);
+
+				input.value = 'Test123';
+				input.dispatchEvent(new Event('input'));
+			});
+		});
+
+		it('should create a live region with aria-live and aria-atomic', () => {
+			const liveRegion = document.querySelector(
+				'.form-validation-list-live-region',
+			);
+			expect(liveRegion).toBeTruthy();
+			expect(liveRegion.getAttribute('aria-live')).toBe('polite');
+			expect(liveRegion.getAttribute('aria-atomic')).toBe('true');
+		});
+
+		it('should update the live region with the announcement after validation', async () => {
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'Test123';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				const liveRegion = document.querySelector(
+					'.form-validation-list-live-region',
+				);
+				expect(liveRegion.textContent).toContain('3');
+			});
+		});
+
+		it('should replace all matched and total placeholders in announcement', async () => {
+			element.setAttribute(
+				'announcement',
+				'Matched {matched}/{matched} of {total}/{total}',
+			);
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'Test123';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				const liveRegion = document.querySelector(
+					'.form-validation-list-live-region',
+				);
+				expect(liveRegion.textContent).toBe('Matched 3/3 of 3/3');
+			});
+		});
+
+		it('should suspend aria-describedby on input and restore on blur', () => {
+			vi.useFakeTimers();
+
+			try {
+				element.setAttribute('each-delay', '0');
+				element.setAttribute('input-throttle', '0');
+				element.disconnectedCallback();
+				element.connectedCallback();
+
+				const listId = element.querySelector('ul, ol').id;
+				expect(input.getAttribute('aria-describedby')).toContain(
+					listId,
+				);
+
+				input.value = 'A';
+				input.dispatchEvent(new Event('input'));
+				const describedByDuringTyping =
+					input.getAttribute('aria-describedby');
+				expect(
+					describedByDuringTyping === null ||
+						!describedByDuringTyping.includes(listId),
+				).toBe(true);
+
+				input.dispatchEvent(new Event('blur'));
+				const describedByAfterBlur =
+					input.getAttribute('aria-describedby');
+				expect(
+					describedByAfterBlur === null ||
+						!describedByAfterBlur.includes(listId),
+				).toBe(true);
+
+				vi.advanceTimersByTime(200);
+				expect(input.getAttribute('aria-describedby')).toContain(
+					listId,
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should toggle has-value class based on field content', async () => {
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			expect(element.classList.contains('has-value')).toBe(false);
+
+			input.value = 'A';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(element.classList.contains('has-value')).toBe(true);
+			});
+
+			input.value = '';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(element.classList.contains('has-value')).toBe(false);
+			});
+		});
+	});
+
+	describe('configuration attributes', () => {
+		it('should use default trigger event', () => {
+			expect(element.triggerEvent).toBe('input');
+		});
+
+		it('should allow custom trigger event', () => {
+			element.setAttribute('trigger-event', 'blur');
+			expect(element.triggerEvent).toBe('blur');
+		});
+
+		it('should use default each-delay', () => {
+			expect(element.eachDelay).toBe(150);
+		});
+
+		it('should use default input-throttle', () => {
+			expect(element.inputThrottle).toBe(250);
+		});
+
+		it('should allow custom input-throttle', () => {
+			element.setAttribute('input-throttle', '40');
+			expect(element.inputThrottle).toBe(40);
+		});
+
+		it('should allow custom each-delay', () => {
+			element.setAttribute('each-delay', '200');
+			expect(element.eachDelay).toBe(200);
+		});
+
+		it('should use default class names', () => {
+			expect(element.fieldInvalidClass).toBe('validation-invalid');
+			expect(element.fieldValidClass).toBe('validation-valid');
+			expect(element.ruleUnmatchedClass).toBe('validation-unmatched');
+			expect(element.ruleMatchedClass).toBe('validation-matched');
+		});
+
+		it('should use default icon alt text', () => {
+			expect(element.ruleMatchedAlt).toBe('Criteria met');
+			expect(element.ruleUnmatchedAlt).toBe('Criteria not met');
+		});
+
+		it('should allow custom icon alt text', () => {
+			element.setAttribute('rule-matched-alt', 'Met');
+			element.setAttribute('rule-unmatched-alt', 'Not met');
+			expect(element.ruleMatchedAlt).toBe('Met');
+			expect(element.ruleUnmatchedAlt).toBe('Not met');
+		});
+
+		it('should use default announcement template', () => {
+			expect(element.announcement).toBe(
+				'Criteria met: {matched} of {total}',
+			);
+		});
+
+		it('should allow custom announcement template', () => {
+			element.setAttribute('announcement', '{matched}/{total} ok');
+			expect(element.announcement).toBe('{matched}/{total} ok');
+		});
+
+		it('should allow custom icons via attribute', () => {
+			element.setAttribute('rule-matched-icon', '✅');
+			element.setAttribute('rule-unmatched-icon', '❌');
+			expect(element.ruleMatchedIcon).toBe('✅');
+			expect(element.ruleUnmatchedIcon).toBe('❌');
+		});
+
+		it('should allow custom class names', () => {
+			element.setAttribute('field-invalid-class', 'custom-invalid');
+			element.setAttribute('field-valid-class', 'custom-valid');
+			element.setAttribute('rule-unmatched-class', 'custom-unmatched');
+			element.setAttribute('rule-matched-class', 'custom-matched');
+
+			expect(element.fieldInvalidClass).toBe('custom-invalid');
+			expect(element.fieldValidClass).toBe('custom-valid');
+			expect(element.ruleUnmatchedClass).toBe('custom-unmatched');
+			expect(element.ruleMatchedClass).toBe('custom-matched');
+		});
+
+		it('should rebind validation handler when trigger-event changes', async () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			element.setAttribute('trigger-event', 'blur');
+			input.value = 'TEST';
+			input.dispatchEvent(new Event('blur'));
+
+			await waitFor(() => {
+				expect(
+					element
+						.querySelector('[data-pattern]')
+						.classList.contains('validation-matched'),
+				).toBe(true);
+			});
+		});
+
+		it('should refresh field classes when field-valid-class changes', async () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'TEST';
+			input.dispatchEvent(new Event('input'));
+			await waitFor(() => {
+				expect(input.classList.contains('validation-valid')).toBe(true);
+			});
+
+			element.setAttribute('field-valid-class', 'custom-good');
+			await waitFor(() => {
+				expect(input.classList.contains('custom-good')).toBe(true);
+				expect(input.classList.contains('validation-valid')).toBe(
+					false,
+				);
+			});
+		});
+
+		it('should refresh rule classes when rule-matched-class changes', async () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'TEST';
+			input.dispatchEvent(new Event('input'));
+			await waitFor(() => {
+				expect(
+					element
+						.querySelector('[data-pattern]')
+						.classList.contains('validation-matched'),
+				).toBe(true);
+			});
+
+			element.setAttribute('rule-matched-class', 'custom-match');
+			await waitFor(() => {
+				const rule = element.querySelector('[data-pattern]');
+				expect(rule.classList.contains('custom-match')).toBe(true);
+				expect(rule.classList.contains('validation-matched')).toBe(
+					false,
+				);
+			});
+		});
+
+		it('should throttle input-triggered validation and use latest value', () => {
+			vi.useFakeTimers();
+
+			try {
+				element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+				element.setAttribute('each-delay', '0');
+				element.setAttribute('input-throttle', '100');
+				element.disconnectedCallback();
+				element.connectedCallback();
+
+				const rule = element.querySelector('[data-pattern]');
+
+				input.value = 'abc';
+				input.dispatchEvent(new Event('input'));
+
+				input.value = 'ABC';
+				input.dispatchEvent(new Event('input'));
+
+				expect(rule.classList.contains('validation-matched')).toBe(
+					false,
+				);
+				expect(rule.classList.contains('validation-unmatched')).toBe(
+					false,
+				);
+
+				vi.advanceTimersByTime(100);
+
+				expect(rule.classList.contains('validation-matched')).toBe(
+					true,
+				);
+				expect(rule.classList.contains('validation-unmatched')).toBe(
+					false,
+				);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should not throttle blur trigger events', () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital letter</li></ul>`;
+			element.setAttribute('trigger-event', 'blur');
+			element.setAttribute('input-throttle', '1000');
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			const rule = element.querySelector('[data-pattern]');
+			input.value = 'ABC';
+			input.dispatchEvent(new Event('blur'));
+
+			expect(rule.classList.contains('validation-matched')).toBe(true);
+			expect(rule.classList.contains('validation-unmatched')).toBe(false);
+		});
+	});
+
+	describe('public API', () => {
+		beforeEach(() => {
+			element.innerHTML = `
 				<ul>
 					<li data-pattern="[A-Z]+">Capital letter</li>
 					<li data-pattern="[0-9]+">Number</li>
 				</ul>
 			`;
-      element.disconnectedCallback();
-      element.connectedCallback();
-    });
+			element.disconnectedCallback();
+			element.connectedCallback();
+		});
 
-    it('should provide validate() method', () => {
-      expect(typeof element.validate).toBe('function');
-    });
+		it('should provide validate() method', () => {
+			expect(typeof element.validate).toBe('function');
+		});
 
-    it('validate() should return validation state', () => {
-      input.value = 'Test123';
-      const isValid = element.validate();
-      expect(typeof isValid).toBe('boolean');
-    });
+		it('validate() should return validation state', () => {
+			input.value = 'Test123';
+			const isValid = element.validate();
+			expect(typeof isValid).toBe('boolean');
+		});
 
-    it('should provide isValid getter', () => {
-      input.value = 'Test123';
-      element.validate();
-      expect(typeof element.isValid).toBe('boolean');
-    });
-  });
+		it('should provide isValid getter', () => {
+			input.value = 'Test123';
+			element.validate();
+			expect(typeof element.isValid).toBe('boolean');
+		});
+	});
 
-  describe('cleanup', () => {
-    it('should remove only this id from aria-describedby when disconnected', () => {
-      input.setAttribute('aria-describedby', 'existing-id');
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-      element.disconnectedCallback();
-      element.connectedCallback();
+	describe('cleanup', () => {
+		it('should remove only this id from aria-describedby when disconnected', () => {
+			input.setAttribute('aria-describedby', 'existing-id');
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+			element.disconnectedCallback();
+			element.connectedCallback();
 
-      const listId = element.querySelector('ul, ol').id;
-      expect(input.getAttribute('aria-describedby')).toContain(
-        'existing-id',
-      );
-      expect(input.getAttribute('aria-describedby')).toContain(listId);
+			const listId = element.querySelector('ul, ol').id;
+			expect(input.getAttribute('aria-describedby')).toContain(
+				'existing-id',
+			);
+			expect(input.getAttribute('aria-describedby')).toContain(listId);
 
-      element.disconnectedCallback();
+			element.disconnectedCallback();
 
-      expect(input.getAttribute('aria-describedby')).toBe('existing-id');
-    });
+			expect(input.getAttribute('aria-describedby')).toBe('existing-id');
+		});
 
-    it('should cleanup when disconnected', async () => {
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-      element.setAttribute('each-delay', '0');
-      element.disconnectedCallback();
-      element.connectedCallback();
+		it('should cleanup when disconnected', async () => {
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+			element.setAttribute('each-delay', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
 
-      input.value = 'Test';
-      input.dispatchEvent(new Event('input'));
-      await waitFor(() => {
-        expect(input.classList.contains('validation-valid')).toBe(true);
-      });
+			input.value = 'Test';
+			input.dispatchEvent(new Event('input'));
+			await waitFor(() => {
+				expect(input.classList.contains('validation-valid')).toBe(true);
+			});
 
-      element.disconnectedCallback();
+			element.disconnectedCallback();
 
-      // Field should not have validation classes after cleanup
-      expect(input.classList.contains('validation-valid')).toBe(false);
-      expect(input.classList.contains('validation-invalid')).toBe(false);
-    });
+			// Field should not have validation classes after cleanup
+			expect(input.classList.contains('validation-valid')).toBe(false);
+			expect(input.classList.contains('validation-invalid')).toBe(false);
+		});
 
-    it('should cleanup when for attribute changes', () => {
-      const nextInput = document.createElement('input');
-      nextInput.type = 'text';
-      nextInput.id = 'next-input';
-      document.body.appendChild(nextInput);
+		it('should cleanup when for attribute changes', () => {
+			const nextInput = document.createElement('input');
+			nextInput.type = 'text';
+			nextInput.id = 'next-input';
+			document.body.appendChild(nextInput);
 
-      element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
-      element.disconnectedCallback();
-      element.connectedCallback();
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+			element.disconnectedCallback();
+			element.connectedCallback();
 
-      const oldField = element._field;
-      oldField.setAttribute('aria-describedby', 'existing-id');
-      element._setupAccessibility();
+			const oldField = element._field;
+			oldField.setAttribute('aria-describedby', 'existing-id');
+			element._setupAccessibility();
 
-      element.setAttribute('for', 'next-input');
+			element.setAttribute('for', 'next-input');
 
-      expect(element._field).not.toBe(oldField);
-      expect(oldField.getAttribute('aria-describedby')).toBe(
-        'existing-id',
-      );
-    });
-  });
+			expect(element._field).not.toBe(oldField);
+			expect(oldField.getAttribute('aria-describedby')).toBe(
+				'existing-id',
+			);
+		});
+	});
 });

--- a/test/form-validation-list.test.js
+++ b/test/form-validation-list.test.js
@@ -217,6 +217,24 @@ describe('FormValidationListElement', () => {
 			});
 		});
 
+		it('should replace all placeholders in validation-message template', async () => {
+			element.setAttribute(
+				'validation-message',
+				'Matched {matched}/{matched} of {total}/{total}',
+			);
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'test';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				expect(input.validationMessage).toBe('Matched 1/1 of 3/3');
+			});
+		});
+
 		it('should fire validation event', () => {
 			return new Promise((resolve) => {
 				element.addEventListener(
@@ -246,6 +264,7 @@ describe('FormValidationListElement', () => {
 
 		it('should update the live region with the announcement after validation', async () => {
 			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
 			element.disconnectedCallback();
 			element.connectedCallback();
 
@@ -257,6 +276,27 @@ describe('FormValidationListElement', () => {
 					'.form-validation-list-live-region',
 				);
 				expect(liveRegion.textContent).toContain('3');
+			});
+		});
+
+		it('should replace all matched and total placeholders in announcement', async () => {
+			element.setAttribute(
+				'announcement',
+				'Matched {matched}/{matched} of {total}/{total}',
+			);
+			element.setAttribute('each-delay', '0');
+			element.setAttribute('input-throttle', '0');
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			input.value = 'Test123';
+			input.dispatchEvent(new Event('input'));
+
+			await waitFor(() => {
+				const liveRegion = element.querySelector(
+					'.form-validation-list-live-region',
+				);
+				expect(liveRegion.textContent).toBe('Matched 3/3 of 3/3');
 			});
 		});
 
@@ -552,6 +592,23 @@ describe('FormValidationListElement', () => {
 	});
 
 	describe('cleanup', () => {
+		it('should remove only this id from aria-describedby when disconnected', () => {
+			input.setAttribute('aria-describedby', 'existing-id');
+			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
+			element.disconnectedCallback();
+			element.connectedCallback();
+
+			const listId = element.id;
+			expect(input.getAttribute('aria-describedby')).toContain(
+				'existing-id',
+			);
+			expect(input.getAttribute('aria-describedby')).toContain(listId);
+
+			element.disconnectedCallback();
+
+			expect(input.getAttribute('aria-describedby')).toBe('existing-id');
+		});
+
 		it('should cleanup when disconnected', async () => {
 			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
 			element.setAttribute('each-delay', '0');
@@ -572,14 +629,25 @@ describe('FormValidationListElement', () => {
 		});
 
 		it('should cleanup when for attribute changes', () => {
+			const nextInput = document.createElement('input');
+			nextInput.type = 'text';
+			nextInput.id = 'next-input';
+			document.body.appendChild(nextInput);
+
 			element.innerHTML = `<ul><li data-pattern="[A-Z]+">Capital</li></ul>`;
 			element.disconnectedCallback();
 			element.connectedCallback();
 
 			const oldField = element._field;
-			element.setAttribute('for', 'non-existent');
+			oldField.setAttribute('aria-describedby', 'existing-id');
+			element._setupAccessibility();
+
+			element.setAttribute('for', 'next-input');
 
 			expect(element._field).not.toBe(oldField);
+			expect(oldField.getAttribute('aria-describedby')).toBe(
+				'existing-id',
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

Improves the screen reader experience for validation lists by consolidating typing feedback into a single live announcement and restoring full criteria context when the field is revisited.

## What changed

- move typing announcements to a single polite live region on the component
- suspend `aria-describedby` while typing and restore it on blur with a short delay
- preserve native list semantics instead of forcing ARIA list roles
- render rule state in the DOM with decorative icon spans plus hidden localized state text
- add configurable announcement and rule icon/state text attributes
- align CSS custom properties to `--rule-*` names while preserving legacy `--validation-*` fallbacks
- update tests, metadata, README, and demos to match the new behavior

Closes #4